### PR TITLE
Embedded Document saving and retrieving to mongodb failed

### DIFF
--- a/dictshield/fields.py
+++ b/dictshield/fields.py
@@ -394,7 +394,7 @@ class EmbeddedDocumentField(BaseField):
     def for_python(self, value):
         if not isinstance(value, self.document_type):
             return self.document_type._from_son(value)
-        return value
+        return value.to_python()
 
     def for_json(self, value):
         if not isinstance(value, self.document_type):


### PR DESCRIPTION
When trying to save an embedded object to mongodb it fails cause the embedded object return instance of embedded object rather than python dict...

The problem is resolved if the value.to_python() is return from for_python method of embeddedField.
This might be a design decision on your part.  I'm still undecided if it's better to return the instance or a dict...

Also related to this, a bug in basedocument from_son().  fb_field doesn't exists... I changed it field_name and issue was resolved... also to_python method for field doesn't exists it's for_python()...

The problem here is that from_son return instance of embedded doc while now for python returns dict of embedded doc.    inconsistent behavior therefore wrong solution.  

I was thinking maybe the db save method should check for embedded object but it seems to make db integration less easy...  
