### PR TITLE
Quick solution to serialize datetime to JSON

### DIFF
--- a/dictshield/fields.py
+++ b/dictshield/fields.py
@@ -245,6 +245,9 @@ class DateTimeField(BaseField):
     """A datetime field.
     """
 
+    def for_json(self, value):
+        return value.isoformat()
+
     def validate(self, value):
         if not isinstance(value, datetime.datetime):
             raise DictPunch('Not a datetime', self.field_name, value)


### PR DESCRIPTION
Uses isoformat() on the datetime object to return an ISO-compliant
string
