### PR TITLE
Make microseconds optional in DateTimeField parsing

### DIFF
--- a/dictshield/fields.py
+++ b/dictshield/fields.py
@@ -270,11 +270,17 @@ class DateTimeField(BaseField):
         ISO8601's elements come in the same order as the inputs to creating
         a datetime.datetime.  I pass the patterns directly into the datetime
         constructor.
+
+        The ISO8601 spec is rather complex and allows for many variations in
+        formatting values.  Currently the format expected is strict, with the
+        only optional component being the six-digit microsecond field.
+
+        http://www.w3.org/TR/NOTE-datetime
         """
-        iso8601 = '(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)\.(\d\d\d\d\d\d)'
+        iso8601 = '(\d\d\d\d)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)(?:\.(\d\d\d\d\d\d))?'
         elements = re.findall(iso8601, datestring)
         date_info = elements[0]
-        date_digits = [int(d) for d in date_info]
+        date_digits = [int(d) for d in date_info if d]
         value = datetime.datetime(*date_digits)
         return value
 


### PR DESCRIPTION
When Python creates datetime values that don't explicitly set a value for microseconds, this portion is not provided when converting to a string.  As a result, these values will fail to be parsed into DateTimeField by DictShield.

This update to the regex merely adds a non-matching group to make the last '.(\d\d\d\d\d\d)' group optional, and will only add fields to the list for datetime creation if they have a value.  Because the only optionally-matching field in the regex is microseconds, the end result is that the only case where the 'if' will apply is the case when the microseconds field does not match.

Because ISO8601 allows for wide variation in formatting, this will have to be revisited in the future when further handling of ISO8601 values is to be added to DictShield.
