### PR TITLE
Added a UUID Field Type

### DIFF
--- a/dictshield/fields.py
+++ b/dictshield/fields.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 import re
 import datetime
 import decimal
+import uuid
 
 __all__ = ['StringField', 'IntField', 'FloatField', 'LongField', 'BooleanField',
            'DateTimeField', 'EmbeddedDocumentField', 'ListField', 'DictField',
@@ -442,6 +443,44 @@ class GeoPointField(BaseField):
                                   'k2: v2}',
                                   self.field_name, value)
 
+
+class UUIDField(BaseField):
+    """A field that stores a valid UUID value and optionally auto-populates empty
+    values with new UUIDs.
+    """
+
+    def __init__(self, auto_fill=True, **kwargs):
+        self.auto_fill = auto_fill
+        super(UUIDField, self).__init__(**kwargs)
+
+    def __set__(self, instance, value):
+        """Convert any text values provided into Python UUID objects and
+        auto-populate any empty values should auto_fill be set to True.
+        """
+        if not value:
+            value = uuid.uuid4()
+
+        if isinstance(value, (str, unicode)):
+            value = uuid.UUID(value)
+
+        instance._data[self.field_name] = value
+
+    def validate(self, value):
+        """Make sure the value is a valid uuid representation.  See
+        http://docs.python.org/library/uuid.html for accepted formats.
+        """
+        if not isinstance(value, (uuid.UUID,)):
+            try:
+                uuid.UUID(value)
+            except ValueError:
+                raise ShieldException('Not a valid UUID value',
+                    self.field_name, value)
+
+    def for_json(self, value):
+        """Return a JSON safe version of the UUID object.
+        """
+
+        return str(value)
 
 ###
 ### Sub structures


### PR DESCRIPTION
Often it can be useful to use UUIDs in large distributed systems.  Accordingly I added a field type that accepts a variety of string UUID representations or UUID objects as a value, validates them, and provides a for_json value to output a string representation of the UUID for use within JSON.

Additionally the field has an optional argument which populates its value with a new UUID should an empty value be passed in to start with.
