### PR TITLE
Fixed a subtle bug with ListFields

### DIFF
--- a/dictshield/fields/base.py
+++ b/dictshield/fields/base.py
@@ -310,7 +310,7 @@ class ListField(BaseField):
             raise InvalidShield('Argument to ListField constructor must be '
                                 'a valid field')
         self.field = field
-        kwargs.setdefault('default', list())
+        kwargs.setdefault('default', list)
         super(ListField, self).__init__(**kwargs)
 
     def __set__(self, instance, value):


### PR DESCRIPTION
Sorry for the verbose explanation here, the bug here is pretty subtle and hard to track down.

The default set in the  `__init__` for `ListField` was `list()`.  The problem with this is that the `__init__` method is only called when the class using the ListField is imported, it's not called when an instance of that class is created.  This results in the mutable list created in the **init** method becoming global to all instances of a document class.

If one only ever overwrites the value of a list field they won't notice this problem.  However, if you start from the default value on an instance and manipulate that value (e.g. append), you end up manipulating the value on all instances that haven't had that field's value overridden from the default.

The fix in the attached patch changes the default for the `ListField` to just `list` instead of `list()`.  This results in the `list` function getting called on individual instances when the field is accessed and no value has been set.

As a general guideline going forward we should probably make sure that default values should only ever be immutable values (ints, strings) or callables.
