### PR TITLE
New format constructor argument for DateTimeField

### DIFF
--- a/dictshield/fields/base.py
+++ b/dictshield/fields/base.py
@@ -517,7 +517,7 @@ class DateTimeField(BaseField):
     def _jsonschema_type(self):
         return 'string'
 
-    def __init__(self, format=None, **kwargs):
+    def __init__(self, format=lambda dt: dt.isoformat(), **kwargs):
         self.format = format
         super(DateTimeField, self).__init__(**kwargs)
 
@@ -574,21 +574,18 @@ class DateTimeField(BaseField):
         return value
 
     @classmethod
-    def date_to_iso8601(cls, dt, format=None):
+    def date_to_iso8601(cls, dt, format):
         """Classmethod that goes the opposite direction of iso8601_to_date.
            Defaults to using isoformat(), but can use the optional format
            argument either as a strftime format string or as a custom
            date formatting function or lambda.
         """
-        if format is not None:
-            if isinstance(format, str):
-                iso_dt = dt.strftime(format)
-            elif hasattr(format, '__call__'):
-                iso_dt = format(dt)
-            else:
-                raise ShieldException('DateTimeField format must be a string or callable')
+        if isinstance(format, str):
+            iso_dt = dt.strftime(format)
+        elif hasattr(format, '__call__'):
+            iso_dt = format(dt)
         else:
-            iso_dt = dt.isoformat()
+            raise ShieldException('DateTimeField format must be a string or callable')
         return iso_dt
 
     def validate(self, value):


### PR DESCRIPTION
Problem: there aren't many APIs out there which expect JSON dates to be formatted in the Python `isoformat()` format currently output by DictShield. 

To work around this I've added a new `format` argument to `DateTimeField`, which can take either a string (which is a `strftime` [format](http://docs.python.org/library/datetime.html#strftime-and-strptime-behavior)) or a custom function/lambda to output a formatted date.

Example usages:

```
ordered_at = DateTimeField(format="%Y-%m-%dT%H:%M:%S%z")
```

Or:

```
date_formatter = lambda dt : dt.strftime("%Y%m%dT%H:%M:%S.%f")[:-3] # Truncate micro- to milliseconds
last_updated = DateTimeField(format=date_formatter, required=True)
```
