### PR TITLE
default fields=None raises an Exception

### DIFF
--- a/dictshield/fields/compound.py
+++ b/dictshield/fields/compound.py
@@ -148,7 +148,7 @@ class SortedListField(ListField):
 
     _ordering = None
 
-    def __init__(self, field=None, **kwargs):
+    def __init__(self, field, **kwargs):
         if 'ordering' in kwargs.keys():
             self._ordering = kwargs.pop('ordering')
         super(SortedListField, self).__init__(field, **kwargs)


### PR DESCRIPTION
The current version of ListField defaults to fields=None, but this raises an exception.  It would seem to make more sense in this case to not give it a default.
