### PR TITLE
Make DatetimeField's __set__ compatible with the default string represen...

### DIFF
--- a/dictshield/fields/base.py
+++ b/dictshield/fields/base.py
@@ -557,7 +557,7 @@ class DateTimeField(BaseField):
             return
 
         if isinstance(value, (str, unicode)):
-            value = DateTimeField.iso8601_to_date(value)
+            value = DateTimeField.iso8601_to_date("T".join(value.split(" ")))
 
         instance._data[self.field_name] = value
 


### PR DESCRIPTION
...tation of Python's standard datetime:

str(datetime_instance) defaults to YYYY-MM-DD HH:MM:SS.mmmmmm, not YYYY-MM-DDTHH:MM:SS.mmmmmm. Adding the T should help conversion.
