### PR TITLE
Fixed a crash when raising a ShieldException upon validating 'choices' and 'validation' field arguments

### DIFF
--- a/dictshield/fields/base.py
+++ b/dictshield/fields/base.py
@@ -85,14 +85,14 @@ class BaseField(object):
         if self.choices is not None:
             if value not in self.choices:
                 raise ShieldException("Value must be one of %s."
-                    % unicode(self.choices))
+                    % unicode(self.choices), self.field_name, value)
 
         # check validation argument
         if self.validation is not None:
             if callable(self.validation):
                 if not self.validation(value):
                     raise ShieldException('Value does not match custom' \
-                                          'validation method.')
+                                          'validation method.', self.field_name, value)
             else:
                 raise ValueError('validation argument must be a callable.')
 


### PR DESCRIPTION
The following would crash on m.validate():

```
from dictshield.document import Document
from dictshield.fields import StringField

class Media(Document):
    title = StringField(choices=['choice1', 'choice2'])

def test():
    m = Media()
    m.title = 'nochance'
    m.validate()

if __name__ == '__main__':
    test()
```

The same crash would happen when defining a callable validation method for the field.
