### PR TITLE
Updated the Document's validate() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.pyc
 *.bak
+*.swp
 *.*~
 .ropeproject
 ./#*

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ MongoDB, Riak, whatever you need.
     ...
     >>> data = {'name':'a hacker', 'body':'DictShield makes validation easy'}
     >>> Comment(**data).validate()
+    True
     
 Let's see what happens if we try using invalid data.
     
@@ -438,11 +439,15 @@ like we attempted above.
 
 ### Aggregating Errors
 
-`validate_class_fields` also offers more full validation. Pass
-`validate_all=True` to return 0 or more exceptions. 0 exceptions indicates
-validation was successful.
+DictShield's validation methods can also give you a list of which individual fields
+failed validation.  Calling a Document's `validate()` method with `validate_all=True`
+will raise a `ShieldDocException` whose `errors_list` attriute is a list of 0 or more
+exceptions, and calling `validate_class_fields` with `validate_all=True` will return the
+same list.
 
     exceptions = User.validate_class_fields(total_input, validate_all=True)
+    if exceptions:
+        # Validation was not successful
 
 
 # Installing

--- a/dictshield/base.py
+++ b/dictshield/base.py
@@ -54,5 +54,20 @@ class ShieldException(Exception):
 DictPunch = ShieldException
 
 
+class ShieldDocException(Exception):
+    """The Document did not pass validation
+            doc - name of the model that did not validate
+            error_list - list of ShieldExceptions that have been raised
+    """
+    def __init__(self, doc_name, error_list, *args, **kwargs):
+        super(ShieldDocException, self).__init__(*args, **kwargs)
+        self.doc = doc_name
+        self.error_list = error_list
+
+    def __str__(self):
+        return 'Document had %d errors - %s' % (len(self.error_list),
+                [e.__str__() for e in self.error_list],)
+
+
 def subclass_exception(name, parents, module):
     return type(name, parents, {'__module__': module})


### PR DESCRIPTION
as discussed in https://github.com/j2labs/dictshield/issues/74

It now returns a `ShieldDocException` when called with arg `validate_all=True`.
The exception's `error_list` attribute contains a list of all the `ShieldExceptions` from the individual fields, same as the list returned by the classmethod `validate_class_fields`

`validate()` called without any args works the same as before.
