### PR TITLE
proposing a change to validation behavior

### DIFF
--- a/dictshield/document.py
+++ b/dictshield/document.py
@@ -311,7 +311,11 @@ class BaseDocument(object):
             # treat empty strings is nonexistent
             if value is not None and value != '':
                 try:
-                    field._validate(value)
+                    # the field may modify the value (e.g. cast a string to an int)
+                    # so shouldn't the new value be placed into the dict of fields?
+                    # otherwise, a string will be deemed valid, but stored in an 
+                    # invalid state.
+                    fields[field] = field._validate(value)
                 except (ValueError, AttributeError, AssertionError):
                     raise ShieldException('Invalid value', field.field_name,
                                           value)


### PR DESCRIPTION
using dictshield for numbers, our web forms were sending in strings. The strings are parseable as integers, so validation was passing (numberfield casts the value as a validation). However, the original string is being kept in the dictionary, so when we pulled the value out later to do some arithmetic, we has str + Integer errors.

our use case was to create a Document, validate it, send the document to be worked on, then persist it. A bit unusual, perhaps, to use the data in the Document before saving, but a reasonable case I hope you will support.

Happy to do more work if you would prefer to see this implemented differently.

thanks,
fawce
