### PR TITLE
fix for ujson

### DIFF
--- a/structures/base.py
+++ b/structures/base.py
@@ -2,11 +2,20 @@
 
 
 ### ultra json is really fast
+json_is_ujson = True
+
 try:
     import ujson as json
 except:
     import json
+    json_is_ujson = False
 
+
+def dumps(data, sort_keys=False):
+    if json_is_ujson:
+        return json.dumps(data)
+    else:
+        return json.dumps(data, sort_keys=sort_keys)
 
 ###
 ### Exceptions

--- a/structures/models.py
+++ b/structures/models.py
@@ -1,7 +1,7 @@
 import inspect
 import copy
 
-from structures.base import TypeException, ModelException, json
+from structures.base import TypeException, ModelException, json, dumps
 
 __all__ = ['ModelMetaclass', 'TopLevelModelMetaclass', 'BaseModel',
            'Model', 'EmbeddedModel', 'TypeException']
@@ -261,7 +261,7 @@ class TopLevelModelMetaclass(ModelMetaclass):
         fun = lambda f, v: f.for_json(v)
         data = self._to_fields(fun)
         if encode:
-            return json.dumps(data, sort_keys=sort_keys)
+            return dumps(data, sort_keys=sort_keys)
         else:
             return data
 
@@ -438,7 +438,7 @@ class BaseModel(object):
         Certain Structures fields do not map precisely to JSON schema types or
         formats.
         """
-        return json.dumps(cls.for_jsonschema())
+        return dumps(cls.for_jsonschema())
 
     ###
     ### Instance Serialization
@@ -483,7 +483,7 @@ class BaseModel(object):
         fun = lambda f, v: f.for_json(v)
         data = self._to_fields(fun)
         if encode:
-            return json.dumps(data, sort_keys=sort_keys)
+            return dumps(data, sort_keys=sort_keys)
         else:
             return data
 
@@ -743,7 +743,7 @@ class SafeableMixin:
                               model_converter, model_encoder,
                               field_list=field_list, white_list=white_list)
         if encode:
-            return json.dumps(safed, sort_keys=sort_keys)
+            return dumps(safed, sort_keys=sort_keys)
         else:
             return safed
 
@@ -774,7 +774,7 @@ class SafeableMixin:
                               model_converter, model_encoder,
                               field_list=field_list, white_list=white_list)
         if encode:
-            return json.dumps(safed, sort_keys=sort_keys)
+            return dumps(safed, sort_keys=sort_keys)
         else:
             return safed
 


### PR DESCRIPTION
As far as I can tell ujson.dumps does not support sort_keys as an option and fails.  I added a new base.dumps to base.py that detects if ujson is in use or not and handles things appropriately.  I then refactored all the calls to json.dumps in model.py to use dumps from base.  All tests still passing and now appears to work properly with ujson.
