### PR TITLE
Fix json bug introduced in commit a5cf70551e75bf30384aa805b15492ca7f6df0

### DIFF
--- a/schematics/base.py
+++ b/schematics/base.py
@@ -11,13 +11,14 @@ except ImportError:
     json_is_ujson = False
 
 
+json_dumps = json.dumps
 @functools.wraps(json.dumps)
 def _dumps(*args, **kwargs):
     """Wrapper for ujson.dumps which removes the 'sort_keys' kwarg. Regular
     json.dumps supports sort_keys but ujson.dumps does not.
     """
     kwargs.pop('sort_keys', None)
-    return json.dumps(*args, **kwargs)
+    return json_dumps(*args, **kwargs)
 
 
 # Only patch if we are using ujson


### PR DESCRIPTION
In line 24 of base.py you are monkey patching json with a new dumps method. However the new method does not support and pass through all of the kwargs that the original json.dumps method supported. It therefore breaks usage of the json.dumps method anywhere else.
