### PR TITLE
Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='schematics',
       license='BSD',
@@ -9,4 +9,5 @@ setup(name='schematics',
       author='James Dennis',
       author_email='jdennis@gmail.com',
       url='http://github.com/j2labs/schematics',
-      packages=['schematics', 'schematics.types'])
+      packages=['schematics', 'schematics.types'],
+      use_2to3=True)


### PR DESCRIPTION
It would be nice if we could use `schematics` with Python 3.  The attached change just fires up `2to3` when `setup.py` is running under Python 3, and for my usage that appears to be Good Enough™ [1].

However, I'm opening this pull request mostly to start a discussion…

Do you even _want_ to support Python 3?

Would you rather support it directly without the `2to3` step?  It would require a few nasty changes, such as the [dirtiness I added to `github2`](https://github.com/ask/python-github2/blob/master/github2/core.py#L347).  You can avoid some of that if you're willing to depend on `six` though.

Thanks and sorry for the rambling,

James
1. I say "good enough" because the test suite hasn't been updated since the rename, so I'm basically guessing ;)
