### PR TITLE
Fix validation error for lists with multiple types.

### DIFF
--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -147,6 +147,17 @@ class TestMultipleEmbeddedData(unittest.TestCase):
         self.assertEqual(actual, expected)
         
 
+
+    def test_validation_on_multitype_list(self):
+        self.testmodel.the_list = [{'bandname': 'fugazi'}]
+
+        try:
+            self.testmodel.validate()
+        except (ValidationError) as e:
+            self.fail("Validation of single type should work, even if its " \
+                      "not valid in the other type.")
+
+
 class TestSetGetSingleScalarDataSorted(unittest.TestCase):
     def setUp(self):
         self.listtype = SortedListType(IntType())
@@ -167,3 +178,6 @@ class TestSetGetSingleScalarDataSorted(unittest.TestCase):
         expected.reverse()
         actual = to_python(self.testmodel)['the_list']
         self.assertEqual(actual, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If you try to perform validation on a multi-type list field, you have errors because in the first type, validation fails but in the second type it succeeds, so we error out b/c errors > 0.

Test included (validated it fails w/o patch).
