### PR TITLE
Falsey defaults

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -54,7 +54,7 @@ class BaseType(object):
     
         value = instance._data.get(self.field_name)
 
-        if value is None and self.default:
+        if value is None and self.default is not None:
             value = self.default
             # Callable values are best for mutable defaults
             if callable(value):

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -29,10 +29,23 @@ class TestIPv4Type(unittest.TestCase):
         fun = lambda: self.Test(ip='1.1.1111.1').validate()
         self.assertNotEqual(ValidationError, fun)
 
+class TestDefaults(unittest.TestCase):
+    class ExampleModel(Model):
+        name = StringType(default='test type')
+        on = BooleanType(default=False)
+
+    def test_truthy_type(self):
+        mod = self.ExampleModel()
+        self.assertEquals('test type', mod.name)
+
+    def test_falsey_type(self):
+        mod = self.ExampleModel()
+        self.assertEquals(False, mod.on)
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestIPv4Type, 'test'))
+    suite.addTest(unittest.makeSuite(TestDefaults, 'test'))
     return suite
 
 


### PR DESCRIPTION
Allow false-y defaults for fields.
    
A good example of this is a BooleanField which has a default of
False. Without the patch it comes back as None.
