### PR TITLE
Split input data from valid data

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -202,7 +202,14 @@ class Model(object):
             Filter output by a specific role
 
         """
-        return serialize(self, role)
+        try:
+            raw_data = self._raw_data
+            self.validate()
+        except ModelValidationError:
+            pass
+        data = serialize(self, role)
+        self._raw_data = raw_data
+        return data
 
     def flatten(self, role=None, prefix=""):
         """

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -172,11 +172,13 @@ class Model(object):
         self._raw_data = self.convert(raw_data) if raw_data else {}
         self._data = {}
 
-    def validate(self, partial=False, strict=False):
+    def validate(self, raw_data=None, partial=False, strict=False):
         """
         Validates the state of the model and adding additional untrusted data
         as well. If the models is invalid, raises ValidationError with error messages.
 
+        :param raw_data:
+            A ``dict`` or ``dict``-like structure for incoming data.
         :param partial:
             Allow partial data to validate; useful for PATCH requests.
             Essentially drops the ``required=True`` arguments from field
@@ -184,6 +186,8 @@ class Model(object):
         :param strict:
             Complain about unrecognized keys. Default: False
         """
+        if raw_data:
+            self._raw_data.update(raw_data)
         if not self._raw_data and partial:
             return  # no input data to validate
         try:
@@ -250,7 +254,7 @@ class Model(object):
                 if raw_value is not None:
                     raw_value = field.convert(raw_value)
                 data[field_name] = raw_value
-                
+
             except KeyError:
                 data[field_name] = field.default
             except ConversionError, e:

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -185,7 +185,7 @@ class Model(object):
         if not self._raw_data:
             return  # no input data to validate
         try:
-            data = validate(self, self._raw_data, partial=partial, strict=strict)
+            data = validate(self, self._raw_data, partial=partial, strict=strict, context=self._data)
             # Set internal data and touch the TypeDescriptors by setattr
             self._data.update(**data)
         except BaseError as e:

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -183,6 +183,14 @@ class Model(object):
             Complain about unrecognized keys. Default: False
         """
         if not self._raw_data:
+            if not partial:
+                # check for empty required fields
+                required = {
+                    field.serialized_name or field_name: [field.messages['required'], ] for
+                    field_name, field, in self._fields.iteritems() if
+                    field.required and self[field_name] is None}
+                if required:
+                    raise ModelValidationError(required)
             return  # no input data to validate
         try:
             data = validate(self, self._raw_data, partial=partial, strict=strict, context=self._data)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -209,7 +209,7 @@ class Model(object):
         """
         try:
             raw_data = self._raw_data
-            self.validate()
+            self.validate(partial=True)
         except ModelValidationError:
             pass
         data = serialize(self, role)

--- a/schematics/serialize.py
+++ b/schematics/serialize.py
@@ -134,7 +134,7 @@ def allow_none(cls, field):
     class setting with it's own ``serialize_when_none`` setting.
     """
     allowed = cls._options.serialize_when_none
-    if field.serialize_when_none != None:
+    if field.serialize_when_none is not None:
         allowed = field.serialize_when_none
     return allowed
 
@@ -167,7 +167,7 @@ def apply_shape(cls, instance_or_dict, role, field_converter, model_converter,
             continue
 
         ### Value found, convert and store it.
-        elif value:  ### TODO make value check for not None
+        elif value is not None:
             if isinstance(field, MultiType):
                 if isinstance(field, ModelType):
                     primitive_value = model_converter(field, value)
@@ -203,11 +203,10 @@ def serialize(instance, role, raise_error_on_role=True):
     """
     field_converter = lambda field, value: field.to_primitive(value)
     model_converter = lambda f, v: f.to_primitive(v, raise_error_on_role)
-    
+
     data = apply_shape(instance.__class__, instance, role, field_converter,
                        model_converter, raise_error_on_role)
     return data
-
 
 
 def expand(data, context=None):
@@ -265,7 +264,7 @@ def flatten(instance, role, raise_error_on_role=True, ignore_none=True,
     i = include_serializables
     field_converter = lambda field, value: field.to_primitive(value)
     model_converter = lambda f, v: f.to_primitive(v, include_serializables=i)
-    
+
     data = apply_shape(instance.__class__, instance, role, field_converter,
                        model_converter,
                        include_serializables=include_serializables)

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -196,7 +196,7 @@ class ListType(MultiType):
                         (self.field.serialize_when_none is None and self.model_class._options.serialize_when_none)):
                         primitive_list.remove(primitive_value)
 
-        return primitive_list if len(primitive_list) > 0 else None
+        return primitive_list
 
 EMPTY_DICT = "{}"
 
@@ -248,15 +248,20 @@ class DictType(MultiType):
         if clean_data is None:
             return primitive_data
 
+        serialize_when_none = True
+
         if isinstance(self.field, MultiType):
+            serialize_when_none = (self.field.serialize_when_none or
+                (self.field.serialize_when_none is None and self.model_class._options.serialize_when_none))
+
             for key, clean_value in clean_data.iteritems():
                 primitive_value = primitive_data[unicode(key)]
 
                 self.field.filter_by_role(clean_value, primitive_value, role)
 
-                if not primitive_value:
-                    if not (self.field.serialize_when_none or
-                        (self.field.serialize_when_none is None and self.model_class._options.serialize_when_none)):
+                if not primitive_value and not serialize_when_none:
                         primitive_data.pop(unicode(key))
 
-        return primitive_data if len(primitive_data) > 0 else None
+        if not primitive_data and not serialize_when_none:
+            return None
+        return primitive_data

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -31,15 +31,13 @@ def validate(model, raw_data, partial=False, strict=False, context=None):
     # validate raw_data by the model fields
     for field_name, field in model._fields.iteritems():
         serialized_field_name = field.serialized_name or field_name
-        try:
-            if serialized_field_name in raw_data:
-                value = raw_data[serialized_field_name]
-            else:
-                value = raw_data[field_name]
-        except KeyError:
-            if data.get(field_name):
-                # skip already validated data
-                continue
+        if serialized_field_name in raw_data:
+            value = raw_data[serialized_field_name]
+        elif field_name in raw_data:
+            value = raw_data[field_name]
+        elif field_name in data:
+            continue  # skip already validated data
+        else:
             value = field.default
 
         if field.required and value is None:

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -40,8 +40,8 @@ def validate(model, raw_data, partial=False, strict=False, context=None):
         else:
             value = field.default
 
-        if field.required and value is None:
-            if not partial:
+        if value is None:
+            if field.required and not partial:
                 errors[serialized_field_name] = [field.messages['required'], ]
         else:
             try:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -13,25 +13,25 @@ class TestFunctionalInterface(unittest.TestCase):
         class Player(Model):
             id = IntType()
 
-        validate(Player, {'id': 4})            
+        validate(Player, {'id': 4})
 
     def test_validate_keep_context_data(self):
         class Player(Model):
             id = IntType()
             name = StringType()
 
-        p1 = Player({'id': 4})
-        data = validate(Player, {'name': 'Arthur'}, context=p1._data)
+        ctx = {'id': 4}
+        data = validate(Player, {'name': 'Arthur'}, context=ctx)
 
         self.assertEqual(data, {'id': 4, 'name': 'Arthur'})
-        self.assertNotEqual(data, p1._data)
+        self.assertNotEqual(data, ctx)
 
     def test_validate_override_context_data(self):
         class Player(Model):
             id = IntType()
 
-        p1 = Player({'id': 4})
-        data = validate(Player, {'id': 3}, context=p1._data)
+        ctx = {'id': 4}
+        data = validate(Player, {'id': 3}, context=ctx)
 
         self.assertEqual(data, {'id': 3})
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,22 @@
+
+import unittest
+
+from schematics.models import Model
+from schematics.types import IntType, StringType
+from schematics.exceptions import ValidationError
+
+
+class TestDataIntegrity(unittest.TestCase):
+
+    def test_dont_serialize_invalid_data(self):
+        """
+        Serialization must always contain just the subset of valid
+        data from the model.
+
+        """
+        class Player(Model):
+            code = StringType(max_length=4)
+
+        p1 = Player({'code': 'invalid1'})
+        self.assertRaises(ValidationError, p1.validate)
+        self.assertEqual(p1.serialize(), {'code': None})

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -64,3 +64,16 @@ class TestDataIntegrity(unittest.TestCase):
         self.assertEqual(p1.serialize(), {'id': 4, 'code': 'BBB'})
         p1.validate()
         self.assertEqual(p1.serialize(), {'id': 4, 'code': 'BBB'})
+
+    def test_dont_forget_required_fields_after_multiple_validation(self):
+        """
+        Validation should not forget about required fields, even if invalid
+        data is cleared from input, since it doesn't rely on actual input.
+
+        """
+        class Player(Model):
+            code = StringType(required=True)
+
+        p1 = Player()
+        self.assertRaises(ModelValidationError, p1.validate)
+        self.assertRaises(ModelValidationError, p1.validate)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -20,3 +20,21 @@ class TestDataIntegrity(unittest.TestCase):
         p1 = Player({'code': 'invalid1'})
         self.assertRaises(ValidationError, p1.validate)
         self.assertEqual(p1.serialize(), {'code': None})
+
+    def test_dont_overwrite_with_invalid_data(self):
+        """
+        Model-level validators are black-boxes and we should not assume
+        that we can set the instance data at any time.
+
+        """
+        class Player(Model):
+            id = IntType()
+
+            def validate_id(self, context, value):
+                if self.id:
+                    raise ValidationError('Cannot change id')
+
+        p1 = Player({'id': 4})
+        p1.id = 3
+        self.assertRaises(ValidationError, p1.validate)
+        self.assertEqual(p1.id, 4)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -18,6 +18,7 @@ class TestDataIntegrity(unittest.TestCase):
             code = StringType(max_length=4)
 
         p1 = Player({'code': 'invalid1'})
+        self.assertEqual(p1.serialize(), {'code': None})
         self.assertRaises(ModelValidationError, p1.validate)
         self.assertEqual(p1.serialize(), {'code': None})
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -3,7 +3,7 @@ import unittest
 
 from schematics.models import Model
 from schematics.types import IntType, StringType
-from schematics.exceptions import ValidationError
+from schematics.exceptions import ModelValidationError, ValidationError
 
 
 class TestDataIntegrity(unittest.TestCase):
@@ -18,7 +18,7 @@ class TestDataIntegrity(unittest.TestCase):
             code = StringType(max_length=4)
 
         p1 = Player({'code': 'invalid1'})
-        self.assertRaises(ValidationError, p1.validate)
+        self.assertRaises(ModelValidationError, p1.validate)
         self.assertEqual(p1.serialize(), {'code': None})
 
     def test_dont_overwrite_with_invalid_data(self):
@@ -36,5 +36,5 @@ class TestDataIntegrity(unittest.TestCase):
 
         p1 = Player({'id': 4})
         p1.id = 3
-        self.assertRaises(ValidationError, p1.validate)
+        self.assertRaises(ModelValidationError, p1.validate)
         self.assertEqual(p1.id, 4)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -39,3 +39,27 @@ class TestDataIntegrity(unittest.TestCase):
         p1.id = 3
         self.assertRaises(ModelValidationError, p1.validate)
         self.assertEqual(p1.id, 4)
+
+    def test_model_state_after_multiple_validation(self):
+        """
+        Validation must maintain a sane state after multiple operations.
+
+        """
+        class Player(Model):
+            id = IntType()
+            code = StringType(max_length=4)
+
+        p1 = Player({'id': 4})
+        p1.validate()
+        self.assertEqual(p1.serialize(), {'id': 4, 'code': None})
+        p1.code = 'AAA'
+        p1.validate()
+        self.assertEqual(p1.serialize(), {'id': 4, 'code': 'AAA'})
+        p1.code = 'BBB'
+        p1.validate()
+        self.assertEqual(p1.serialize(), {'id': 4, 'code': 'BBB'})
+        p1.code = 'CCCERR'
+        self.assertRaises(ValidationError, p1.validate)
+        self.assertEqual(p1.serialize(), {'id': 4, 'code': 'BBB'})
+        p1.validate()
+        self.assertEqual(p1.serialize(), {'id': 4, 'code': 'BBB'})

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -31,10 +31,11 @@ class TestDataIntegrity(unittest.TestCase):
             id = IntType()
 
             def validate_id(self, context, value):
-                if self.id:
+                if self._data.get('id'):
                     raise ValidationError('Cannot change id')
 
         p1 = Player({'id': 4})
+        p1.validate()
         p1.id = 3
         self.assertRaises(ModelValidationError, p1.validate)
         self.assertEqual(p1.id, 4)

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -48,7 +48,7 @@ class TestListTypeWithModelType(unittest.TestCase):
             slug = StringType()
 
         class PlayerInfo(Model):
-            categories = ListType(ModelType(CategoryStatsInfo), default=lambda: [])
+            categories = ListType(ModelType(CategoryStatsInfo), default=list)
 
         info = PlayerInfo()
         self.assertEqual(info.categories, [])

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -119,14 +119,14 @@ class TestListTypeWithModelType(unittest.TestCase):
             name = StringType()
 
         class Card(Model):
-            users = ListType(ModelType(User), min_size=1)
+            users = ListType(ModelType(User), min_size=1, required=True)
 
         with self.assertRaises(ValidationError) as cm:
             c = Card({"users": None})
             c.validate()
 
         exception = cm.exception
-        self.assertEqual(exception.messages['users'], [u'Please provide at least 1 item.'])
+        self.assertEqual(exception.messages['users'], [u'This field is required.'])
 
         with self.assertRaises(ValidationError) as cm:
             c = Card({"users": []})
@@ -168,7 +168,7 @@ class TestListTypeWithModelType(unittest.TestCase):
         data = {'users': [{'name': u'Doggy'}]}
         c = Card(data)
 
-        c.users = None
+        c.users = []
         with self.assertRaises(ValidationError) as context:
             c.validate()
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -128,7 +128,7 @@ class TestModelLevelValidators(unittest.TestCase):
         self.assertGreater(future, now)
 
         class TestDoc(Model):
-            can_future = BooleanType()
+            can_future = BooleanType(default=False)
             publish = DateTimeType()
 
             def validate_publish(self, data, dt):


### PR DESCRIPTION
Separate new input data from already validated data. This speeds up validation
since it only needs to be run on new data. A couple of data integrity tests are
added too.
