### PR TITLE
Append model fields

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -181,8 +181,7 @@ class ModelMeta(type):
 
     def append_field(cls, name, field):
         if isinstance(field, BaseType):
-            new_field = field.copy()
-            cls._fields[name] = new_field
+            cls._fields[name] = field
             setattr(cls, name, FieldDescriptor(name))
         else:
             raise TypeError('field must be of type %s' % BaseType)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -179,6 +179,14 @@ class ModelMeta(type):
 
         return options_class(cls, **options_members)
 
+    def append_field(cls, name, field):
+        if isinstance(field, BaseType):
+            new_field = field.copy()
+            cls._fields[name] = new_field
+            setattr(cls, name, FieldDescriptor(name))
+        else:
+            raise TypeError('field must be of type %s' % BaseType)
+
     @property
     def fields(cls):
         return cls._fields

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -116,6 +116,12 @@ class BaseType(object):
     def __call__(self, value):
         return self.to_native(value)
 
+    def copy(self):
+        copy = object.__new__(self.__class__)
+        copy.__dict__.update(self.__dict__)
+        copy.validators = self.validators[:]
+        return copy
+
     @property
     def default(self):
         default = self._default

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -327,3 +327,25 @@ class TestCompoundTypes(unittest.TestCase):
 
         with self.assertRaises(ConversionError):
             Card({'user': [1, 2]})
+
+
+class TestAppendFields(unittest.TestCase):
+
+    def test_append_new_field(self):
+        class User(Model):
+            pass
+
+        User.append_field('name', StringType())
+
+        u = User({'name': 'Marvin'})
+        self.assertEqual(u.name, 'Marvin')
+
+    def test_append_field_copy(self):
+        class User(Model):
+            name = StringType(default='N/A')
+
+        User.append_field('gender', User.name)
+
+        u = User({'name': 'Marvin'})
+        self.assertEqual(u.name, 'Marvin')
+        self.assertEqual(u.gender, 'N/A')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -340,12 +340,29 @@ class TestAppendFields(unittest.TestCase):
         u = User({'name': 'Marvin'})
         self.assertEqual(u.name, 'Marvin')
 
+    def test_append_same_field(self):
+        shared_type = StringType(required=True)
+
+        class User(Model):
+            name = shared_type
+
+        User.append_field('location', shared_type)
+
+        u = User()
+        self.assertRaises(ValidationError, u.validate)
+        shared_type.required = False
+        u.validate()
+        shared_type.required = True
+        self.assertRaises(ValidationError, u.validate)
+
     def test_append_field_copy(self):
         class User(Model):
-            name = StringType(default='N/A')
+            name = StringType(required=True)
 
-        User.append_field('gender', User.name)
+        User.append_field('gender', User.name.copy())
+        User.gender.required = False
 
-        u = User({'name': 'Marvin'})
-        self.assertEqual(u.name, 'Marvin')
-        self.assertEqual(u.gender, 'N/A')
+        u = User()
+        self.assertEqual(u.name, None)
+        self.assertEqual(u.gender, None)
+        self.assertRaises(ValidationError, u.validate)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -350,9 +350,13 @@ class TestAppendFields(unittest.TestCase):
 
         u = User()
         self.assertRaises(ValidationError, u.validate)
-        shared_type.required = False
+
+        shared_type.required = False  # change the field rules
+        u = User()
         u.validate()
-        shared_type.required = True
+
+        shared_type.required = True  # change them back
+        u = User()
         self.assertRaises(ValidationError, u.validate)
 
     def test_append_field_copy(self):


### PR DESCRIPTION
This adds a method to append new fields to a model class.
Additionally, adds a copy method so that type instances can be copied.

Example:

``` python
class Person(Model):
    name = StringType()

Person.append_field('gender', Person.name.copy())
```
