### PR TITLE
Pass old value to field validation

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -134,7 +134,7 @@ class BaseType(object):
         """
         return value
 
-    def validate(self, value):
+    def validate(self, value, old_value=None):
         """
         Validate the field and return a clean value or raise a
         ``ValidationError`` with a list of errors raised by the validation
@@ -147,7 +147,7 @@ class BaseType(object):
 
         for validator in self.validators:
             try:
-                validator(value)
+                validator(value, old_value)
             except ValidationError, e:
                 errors.extend(e.messages)
 
@@ -157,11 +157,11 @@ class BaseType(object):
         if errors:
             raise ValidationError(errors)
 
-    def validate_required(self, value):
+    def validate_required(self, value, *args):
         if self.required and value is None:
             raise ValidationError(self.messages['required'])
 
-    def validate_choices(self, value):
+    def validate_choices(self, value, *args):
         if self.choices is not None:
             if value not in self.choices:
                 raise ValidationError(self.messages['choices']
@@ -201,7 +201,7 @@ class IPv4Type(BaseType):
         except ValueError:
             return False
 
-    def validate(self, value):
+    def validate(self, value, *args):
         """
           Make sure the value is a IPv4 address:
           http://stackoverflow.com/questions/9948833/validate-ip-address-from-list
@@ -258,7 +258,7 @@ class StringType(BaseType):
 
         return value
 
-    def validate_length(self, value):
+    def validate_length(self, value, *args):
         len_of_value = len(value) if value else 0
 
         if self.max_length is not None and len_of_value > self.max_length:
@@ -267,7 +267,7 @@ class StringType(BaseType):
         if self.min_length is not None and len_of_value < self.min_length:
             raise ValidationError(self.messages['min_length'])
 
-    def validate_regex(self, value):
+    def validate_regex(self, value, *args):
         if self.regex is not None and self.regex.match(value) is None:
             raise ValidationError(self.messages['regex'])
 
@@ -297,7 +297,7 @@ class URLType(StringType):
         self.verify_exists = verify_exists
         super(URLType, self).__init__(**kwargs)
 
-    def validate_url(self, value):
+    def validate_url(self, value, *args):
         if not URLType.URL_REGEX.match(value):
             raise StopValidation(self.messages['invalid_url'])
         if self.verify_exists:
@@ -328,7 +328,7 @@ class EmailType(StringType):
         re.IGNORECASE
     )
 
-    def validate_email(self, value):
+    def validate_email(self, value, *args):
         if not EmailType.EMAIL_REGEX.match(value):
             raise StopValidation(self.messages['email'])
 
@@ -426,7 +426,7 @@ class DecimalType(BaseType):
 
         return value
 
-    def validate_range(self, value):
+    def validate_range(self, value, *args):
         if self.min_value is not None and value < self.min_value:
             raise ValidationError(self.messages['number_min']
                 .format(self.number_type, self.min_value))

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -8,7 +8,7 @@ from .base import BaseType
 
 class MultiType(BaseType):
 
-    def validate(self, value):
+    def validate(self, value, old_value=None):
         """Report dictionary of errors with lists of errors as values of each
         key. Used by ModelType and ListType.
 
@@ -17,7 +17,7 @@ class MultiType(BaseType):
 
         for validator in self.validators:
             try:
-                validator(value)
+                validator(value, old_value)
             except ModelValidationError, e:
                 errors.update(e.messages)
 
@@ -40,7 +40,7 @@ class ModelType(MultiType):
 
         validators = kwargs.pop("validators", [])
 
-        def validate_model(model_instance):
+        def validate_model(model_instance, *args):
             model_instance.validate()
             return model_instance
 
@@ -156,7 +156,7 @@ class ListType(MultiType):
 
         return map(self.field.convert, items)
 
-    def check_length(self, value):
+    def check_length(self, value, *args):
         list_length = len(value) if value else 0
 
         if self.min_size is not None and list_length < self.min_size:
@@ -173,7 +173,7 @@ class ListType(MultiType):
             ) % self.max_size
             raise ValidationError(message)
 
-    def validate_items(self, items):
+    def validate_items(self, items, *args):
         errors = []
         for idx, item in enumerate(items, 1):
             try:
@@ -230,7 +230,7 @@ class DictType(MultiType):
         return dict((self.coerce_key(k), self.field.convert(v))
                     for k, v in value.iteritems())
 
-    def validate_items(self, items):
+    def validate_items(self, items, *args):
         errors = {}
         for key, value in items.iteritems():
             try:

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -48,7 +48,7 @@ def validate(model, raw_data, partial=False, strict=False, context=None):
         else:
             try:
                 value = field.convert(value)
-                field.validate(value)
+                field.validate(value, data.get(field_name))
                 data[field_name] = value
             except BaseError as e:
                 errors[serialized_field_name] = e.messages


### PR DESCRIPTION
This allows state machine validation, that only accept a value if it
corresponds to some valid state transition.

This could previously be implemented by model-level validators, but it makes
sense to add it as a feature of the base types, since you don't need full
instance-access for that, seeing that the validate function already accepts a
context dictionary of previous valid data.
