### PR TITLE
Fixes issue #150. No illegal field exception on validate(strict=True)

### DIFF
--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -111,8 +111,9 @@ def _check_for_unknown_fields(cls, data):
         Errors of the fields that were not present in ``cls``.
     """
     errors = {}
-    rogues_found = set(data) - set(cls._fields)
-    if len(rogues_found) > 0:
+    fields = set(getattr(cls, '_initial', {})) | set(data)
+    rogues_found = fields - set(cls._fields)
+    if rogues_found:
         for field_name in rogues_found:
             errors[field_name] = [u'%s is an illegal field.' % field_name]
     return errors

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -13,7 +13,7 @@ class TestFunctionalInterface(unittest.TestCase):
         class Player(Model):
             id = IntType()
 
-        validate(Player, {'id': 4})            
+        validate(Player, {'id': 4})
 
     def test_validate_keep_context_data(self):
         class Player(Model):
@@ -47,10 +47,13 @@ class TestFunctionalInterface(unittest.TestCase):
         class Player(Model):
             id = IntType()
 
-        try:
+        with self.assertRaises(ValidationError) as e:
             data = validate(Player, {'id': 4}, strict=True, context={'name': 'Arthur'})
-        except ValidationError as e:
-            self.assertIn('name', e.messages)
+        self.assertIn('name', e.exception.messages)
+
+        with self.assertRaises(ValidationError) as e:
+            Player({'id': 4, 'name': 'Arthur'}).validate(strict=True)
+        self.assertIn('name', e.exception.messages)
 
     def test_validate_partial_with_context_data(self):
         class Player(Model):


### PR DESCRIPTION
If `_initial` is defined on the `cls` object passed to
`_check_for_unknown_fields`, the fields are also considered when
validating.  This depends on if the object is a `Model` class or
an instance of a `Model` class.

The try/except clause in `test_validate_strict_with_context_data`
caused the test to always pass successfully even though it should
expect an exception.

Added a second test to test for additional fields when validating
a class or validating an instance of that class.
