### PR TITLE
Add NumpyType

### DIFF
--- a/schematics/contrib/numpy.py
+++ b/schematics/contrib/numpy.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import numpy as np
 
-from .base import BaseType
+from ..types.base import BaseType
 from ..exceptions import ValidationError, ConversionError
 
 

--- a/tests/test_numpy_type.py
+++ b/tests/test_numpy_type.py
@@ -3,7 +3,7 @@
 import unittest
 
 from schematics.models import Model
-from schematics.types.numpy import NumpyType
+from schematics.contrib.numpy import NumpyType
 from schematics.exceptions import ValidationError, ConversionError
 
 try:


### PR DESCRIPTION
This adds a NumpyType which has more flexible validation for array types.

Conversion is available for lists and tuples.

Optional validation includes dtype, shape, size and ndim properties.

Strings are not permitted, although they can be converted to numpy arrays, in most cases this would be unintentional. The current code can permit this by passing a string in list form or in a numpy array.

The numpy type is in its own file to avoid making numpy a core dependency of Schematics.
The tests are not run if numpy is not present, making this purely optional.
