### PR TITLE
ListType with DictType

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -33,16 +33,16 @@ class MultiType(BaseType):
                     role=None, print_none=False):
         raise NotImplemented()
 
-    def init_nested_field(self, field, nested_field, **kwargs):
+    def init_compound_field(self, field, compound_field, **kwargs):
         """
         Some of non-BaseType fields requires `field` arg.
-        Not avoid name conflict, provide it as `nested_field`.
+        Not avoid name conflict, provide it as `compound_field`.
         Example:
 
-            comments = ListType(DictType, nested_field=StringType)
+            comments = ListType(DictType, compound_field=StringType)
         """
-        if nested_field:
-            field = field(field=nested_field, **kwargs)
+        if compound_field:
+            field = field(field=compound_field, **kwargs)
         else:
             field = field(**kwargs)
         return field
@@ -117,8 +117,8 @@ class ListType(MultiType):
     def __init__(self, field, min_size=None, max_size=None, **kwargs):
 
         if not isinstance(field, BaseType):
-            nested_field = kwargs.pop('nested_field', None)
-            field = self.init_nested_field(field, nested_field, **kwargs)
+            compound_field = kwargs.pop('compound_field', None)
+            field = self.init_compound_field(field, compound_field, **kwargs)
 
         self.field = field
         self.min_size = min_size
@@ -220,8 +220,8 @@ class DictType(MultiType):
 
     def __init__(self, field, coerce_key=None, **kwargs):
         if not isinstance(field, BaseType):
-            nested_field = kwargs.pop('nested_field', None)
-            field = self.init_nested_field(field, nested_field, **kwargs)
+            compound_field = kwargs.pop('compound_field', None)
+            field = self.init_compound_field(field, compound_field, **kwargs)
 
         self.coerce_key = coerce_key or str
         self.field = field


### PR DESCRIPTION
Currently it is not possible to have list of dicts. This is not working:

```
class NewsModel(BaseModel):
    comments = ListType(DictType, field=StringType)
```

Because ListType expects `field` arg, and DictType also expects `field` arg. As a result, conflict of arguments.

This issue tries to fix it by applying different name for second field arg:

```
class NewsModel(BaseModel):
    comments = ListType(DictType, compound_field=StringType)
```
