### PR TITLE
Change standard coerce_key function to unicode

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -94,14 +94,14 @@ class ModelType(MultiType):
 
         return primitive_data
 
-    def export_loop(self, model_instance, field_converter, 
+    def export_loop(self, model_instance, field_converter,
                     role=None, print_none=False):
         """
         Calls the main `export_loop` implementation because they are both
         supposed to operate on models.
         """
         shaped =  export_loop(self.model_class, model_instance,
-                              field_converter, 
+                              field_converter,
                               role=role, print_none=print_none)
 
         if shaped and len(shaped) == 0 and self.allow_none():
@@ -141,7 +141,7 @@ class ListType(MultiType):
                 raise TypeError()
 
             if isinstance(value, dict):
-                return [value[str(k)] for k in sorted(map(int, value.keys()))]
+                return [value[unicode(k)] for k in sorted(map(int, value.keys()))]
 
             return list(value)
         except TypeError:
@@ -183,7 +183,7 @@ class ListType(MultiType):
     def to_primitive(self, value):
         return map(self.field.to_primitive, value)
 
-    def export_loop(self, list_instance, field_converter, 
+    def export_loop(self, list_instance, field_converter,
                     role=None, print_none=False):
         """Loops over each item in the model and applies either the field
         transform or the multitype transform.  Essentially functions the same
@@ -223,7 +223,7 @@ class DictType(MultiType):
             compound_field = kwargs.pop('compound_field', None)
             field = self.init_compound_field(field, compound_field, **kwargs)
 
-        self.coerce_key = coerce_key or str
+        self.coerce_key = coerce_key or unicode
         self.field = field
 
         validators = [self.validate_items] + kwargs.pop("validators", [])
@@ -260,7 +260,7 @@ class DictType(MultiType):
     def to_primitive(self, value):
         return dict((unicode(k), self.field.to_primitive(v)) for k, v in value.iteritems())
 
-    def export_loop(self, dict_instance, field_converter, 
+    def export_loop(self, dict_instance, field_converter,
                     role=None, print_none=False):
         """Loops over each item in the model and applies either the field
         transform or the multitype transform.  Essentially functions the same


### PR DESCRIPTION
Using str() as the standard coerce_key function results in Problems with dictionary keys containing non-ascii characters:

```
>>> class X(Model):
...     d = DictType(BaseType())
... 
>>> x = X({"d": {u"äöü": "value"}})
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/models.py", line 212, in __init__
    mapping=deserialize_mapping)
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/models.py", line 252, in convert
    return convert(self.__class__, raw_data, **kw)
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/transforms.py", line 368, in convert
    partial=partial, strict=strict, mapping=mapping)
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/transforms.py", line 93, in import_loop
    raw_value = field_converter(field, raw_value)
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/transforms.py", line 366, in <lambda>
    field_converter = lambda field, value: field.to_native(value)
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/types/compound.py", line 247, in to_native
    for k, v in value.iteritems())
  File "/home/tobias/projects/schwaebische/schwaebische-contentpool/eggs/schematics-0.9_4-py2.7.egg/schematics/types/compound.py", line 247, in <genexpr>
    for k, v in value.iteritems())
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```
