### PR TITLE
Fixed typo in variable name (DateTimeType)

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -555,7 +555,7 @@ class DateTimeType(BaseType):
         """
 
         """
-        if isinstance(format, basestring):
+        if isinstance(formats, basestring):
             formats = [formats]
         if formats is None:
             formats = self.DEFAULT_FORMATS


### PR DESCRIPTION
As I see, DateTimeType was intended to accept single format as a string / unicode value. If so, this logic won't work because of a typo (see commit diff). Please, let me know if the fix makes sense. Cheers!
