### PR TITLE
Support exporting ModelType fields with subclassed model instances.

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -100,8 +100,13 @@ class ModelType(MultiType):
         Calls the main `export_loop` implementation because they are both
         supposed to operate on models.
         """
-        shaped =  export_loop(self.model_class, model_instance,
-                              field_converter, 
+        if isinstance(model_instance, self.model_class):
+            model_class = model_instance.__class__
+        else:
+            model_class = self.model_class
+
+        shaped =  export_loop(model_class, model_instance,
+                              field_converter,
                               role=role, print_none=print_none)
 
         if shaped and len(shaped) == 0 and self.allow_none():

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -125,3 +125,25 @@ def test_default_value_when_embedded_model():
 
     assert pack.question.question_id == "1"
     assert pack.question.type == "text"
+
+
+def test_export_loop_with_subclassed_model():
+    class Asset(Model):
+        file_name = StringType()
+
+    class S3Asset(Asset):
+        bucket_name = StringType()
+
+    class Product(Model):
+        title = StringType()
+        asset = ModelType(Asset)
+
+    asset = S3Asset({'bucket_name': 'assets_bucket', 'file_name': 'bar'})
+
+    product = Product({'title': 'baz', 'asset': asset})
+
+    primitive = product.to_primitive()
+    assert 'bucket_name' in primitive['asset']
+
+    native = product.to_native()
+    assert 'bucket_name' in native['asset']


### PR DESCRIPTION
Fixes an issue where exporting a model (either to_native or to_primitive) with ModelType field.  If the value of the field is an instance of a subclass of model class used to instantiate the ModelType, the value is exported as if it was an instance of the base class.

See #184 for a full example.
