### PR TITLE
Uuid cleanup

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -179,10 +179,16 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
 class UUIDType(BaseType):
     """A field that stores a valid UUID value.
     """
+    MESSAGES = {
+        'convert': u"Couldn't interpret value as UUID.",
+    }
 
     def to_native(self, value, context=None):
         if not isinstance(value, uuid.UUID):
-            value = uuid.UUID(value)
+            try:
+                value = uuid.UUID(value)
+            except (AttributeError, TypeError, ValueError):
+                raise ConversionError(self.messages['convert'])
         return value
 
     def to_primitive(self, value, context=None):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,9 +1,11 @@
-import pytest
 import datetime
+import uuid
+
+import pytest
 
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
-    URLType, MultilingualStringType,
+    URLType, MultilingualStringType, UUIDType,
 )
 from schematics.exceptions import ValidationError, ConversionError
 
@@ -203,3 +205,26 @@ def test_multilingual_string_should_accept_lists_of_locales():
     mls = MultilingualStringType()
 
     assert mls.to_primitive(strings, context={'locale': ['foo', 'es_MX', 'fr_FR']}) == 'serpiente'
+
+
+def test_uuid_to_native_from_string():
+    val = '6a10ca93-6ca2-4fc1-b932-6231c0590433'
+
+    assert UUIDType().to_native(val) == uuid.UUID(val)
+
+
+def test_uuid_to_native_from_uuid():
+    val = '6a10ca93-6ca2-4fc1-b932-6231c0590433'
+
+    assert UUIDType().to_native(uuid.UUID(val)) == uuid.UUID(val)
+
+
+def test_uuid_to_native_from_other_values():
+    for val in [
+        'not-a-uuid',
+        'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz',
+        None,
+        123,
+    ]:
+        with pytest.raises(ConversionError):
+            UUIDType().to_native(val)


### PR DESCRIPTION
As of now, `UUIDType.to_native` propagates through exceptions. This is bad because client code has to know about all the ways casting to a UUID can fail; they can't rely on Schematics to raise a ModelValidationError. This fixes the problem for UUIDType, and a similar fix is in the kstrauser/mongo-cleanup@e2fd444 commit.
