### PR TITLE
Boolean values

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -501,6 +501,9 @@ class BooleanType(BaseType):
             elif value in self.FALSE_VALUES:
                 value = False
 
+        if isinstance(value, int) and value in [0, 1]:
+            value = bool(value)
+
         if not isinstance(value, bool):
             raise ConversionError(u'Must be either true or false.')
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,7 @@ import datetime
 
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
-    URLType, MultilingualStringType,
+    URLType, MultilingualStringType, BooleanType,
 )
 from schematics.exceptions import ValidationError, ConversionError
 
@@ -203,3 +203,17 @@ def test_multilingual_string_should_accept_lists_of_locales():
     mls = MultilingualStringType()
 
     assert mls.to_primitive(strings, context={'locale': ['foo', 'es_MX', 'fr_FR']}) == 'serpiente'
+
+
+def test_boolean_to_native():
+    bool_field = BooleanType()
+
+    for true_value in ['True', '1', 1, True]:
+        assert bool_field.to_native(true_value)
+
+    for false_value in ['False', '0', 0, False]:
+        assert not bool_field.to_native(false_value)
+
+    for bad_value in ['TrUe', 'foo', 2, None, 1.0]:
+        with pytest.raises(ConversionError):
+            bool_field.to_native(bad_value)


### PR DESCRIPTION
`BooleanType` now accepts {`0`, `1`} for {`True`, `False`}

Python `bool`s are a subclass of `int`, so this reduces surprise in code that expects the same behavior in `BooleanType`.
