### PR TITLE
Set `None` on a field that's a compound type should honour that semantics

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -46,7 +46,10 @@ class FieldDescriptor(object):
         Checks the field name against a model and sets the value.
         """
         field = instance._fields[self.name]
-        if not isinstance(value, Model) and isinstance(field, ModelType):
+        if all((
+                value is not None,
+                not isinstance(value, Model),
+                isinstance(field, ModelType))):
             value = field.model_class(value)
         instance._data[self.name] = value
 

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -39,6 +39,21 @@ def test_simple_embedded_models_is_none():
     assert p.location is None
 
 
+def test_simple_embedded_model_set_to_none():
+    class Location(Model):
+        country_code = StringType()
+
+    class Player(Model):
+        id = IntType()
+        location = ModelType(Location)
+
+    p = Player(dict(id=1))
+    p.location = None
+
+    assert p.id == 1
+    assert p.location is None
+
+
 def test_simple_embedded_model_is_none_within_listtype():
     class QuestionResources(Model):
         type = StringType()


### PR DESCRIPTION
When a compound field is set to None, set the value
of that field to `None` instead of creating an empty `ModelType` of that
compound object.
