### PR TITLE
give export loop to serializable when type has one

### DIFF
--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -46,6 +46,13 @@ class Serializable(object):
         self.serialized_name = serialized_name
         self.serialize_when_none = serialize_when_none
 
+        if hasattr(type, 'export_loop'):
+            def make_export_loop(_type):
+                def export_loop(*args, **kwargs):
+                    return _type.export_loop(*args, **kwargs)
+                return export_loop
+            self.export_loop = make_export_loop(self.type)
+
     def __get__(self, instance, cls):
         return self.func(instance)
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -116,6 +116,26 @@ def test_serializable_with_model():
     assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
 
 
+def test_serializable_with_model_to_native():
+    class ExperienceLevel(Model):
+        level = IntType()
+        title = StringType()
+
+    class Player(Model):
+        total_points = IntType()
+
+        @serializable(type=ModelType(ExperienceLevel))
+        def xp_level(self):
+            return ExperienceLevel(dict(level=self.total_points * 2, title="Best"))
+
+    player = Player({"total_points": 2})
+
+    assert player.xp_level.level == 4
+
+    d = player.to_native()
+    assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
+
+
 def test_serializable_with_model_when_None():
     class ExperienceLevel(Model):
         level = IntType()


### PR DESCRIPTION
Otherwise serializable fields don't convert during `to_native()`. Test results without fix:

``` python
_____________________________________________ test_serializable_with_model_to_native _____________________________________________

    def test_serializable_with_model_to_native():
        class ExperienceLevel(Model):
            level = IntType()
            title = StringType()

        class Player(Model):
            total_points = IntType()

            @serializable(type=ModelType(ExperienceLevel))
            def xp_level(self):
                return ExperienceLevel(dict(level=self.total_points * 2, title="Best"))

        player = Player({"total_points": 2})

        assert player.xp_level.level == 4

        d = player.to_native()
>       assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
E       assert {'total_point...Level object>} == {'total_points...tle': 'Best'}}
E         Omitting 1 identical items, use -v to show
E         Differing items:
E         {'xp_level': <ExperienceLevel: ExperienceLevel object>} != {'xp_level': {'level': 4, 'title': 'Best'}}
E         Use -v to get the full diff

tests/test_serialize.py:136: AssertionError
```
