### PR TITLE
Create shared environment across nested import/validation loops via a metadata object

### DIFF
--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -183,6 +183,7 @@ class OrderedDict(dict):
 
 
 class Container(dict):
+    """A dictionary that supports access to its elements via the attribute syntax"""
 
     def __init__(self, *args, **kwargs):
         if args and isinstance(args[0], basestring):

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from copy import deepcopy
 from six.moves import zip
 from six import iteritems
@@ -182,14 +183,24 @@ class OrderedDict(dict):
     __iter__ = iterkeys
 
 
-class Container(dict):
-    """A dictionary that supports access to its elements via the attribute syntax"""
+class Container(defaultdict):
+    """
+    A dictionary that provides access to its elements via the attribute syntax
+    and inserts ``None`` when a nonexistent item is requested::
 
+    container.x <=> container['x'] <=> container.setdefault('x', None)
+
+    To get a value without inserting: ``container.get('x', <default>)``.
+
+    To check if a key exists: ``'x' in container``.
+    Please note that ``hasattr()`` does not work because it calls ``__getattr__``.
+
+    Although ``Container`` is a ``defaultdict``, it is instantiated like
+    a regular dict; i.e., the ``None`` generator is added for you.
+    """
     def __init__(self, *args, **kwargs):
-        if args and isinstance(args[0], basestring):
-            self.update(zip(args, (None,) * len(args)))
-            args = ()
-        dict.__init__(self, *args, **kwargs)
+        args = (lambda: None,) + args
+        defaultdict.__init__(self, *args, **kwargs)
 
     def __getattr__(self, name):
         return self[name]
@@ -199,4 +210,13 @@ class Container(dict):
 
     def __delattr__(self, name):
         del self[name]
+
+    def copy(self):
+        return self.__class__(self)
+
+    __copy__ = copy
+
+
+class Environment(Container):
+    pass
 

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -5,6 +5,11 @@ from six import PY3
 
 _missing = object()
 
+try:
+    basestring #PY2
+except NameError:
+    basestring = str #PY3
+
 
 class OrderedDict(dict):
 
@@ -175,3 +180,22 @@ class OrderedDict(dict):
 
     __copy__ = copy
     __iter__ = iterkeys
+
+
+class Container(dict):
+
+    def __init__(self, *args, **kwargs):
+        if args and isinstance(args[0], basestring):
+            self.update(zip(args, (None,) * len(args)))
+            args = ()
+        dict.__init__(self, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return self[name]
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __delattr__(self, name):
+        del self[name]
+

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -236,14 +236,14 @@ class Model(object):
     __optionsclass__ = ModelOptions
 
     def __init__(self, raw_data=None, deserialize_mapping=None,
-                 partial=True, strict=True, meta=None):
+                 partial=True, strict=True, env=None):
         if raw_data is None:
             raw_data = {}
         self._initial = raw_data
         self._data = self.convert(raw_data, strict=strict, partial=partial,
-                                  mapping=deserialize_mapping, meta=meta)
+                                  mapping=deserialize_mapping, env=env)
 
-    def validate(self, partial=False, strict=False, meta=None):
+    def validate(self, partial=False, strict=False, env=None):
         """
         Validates the state of the model and adding additional untrusted data
         as well. If the models is invalid, raises ValidationError with error
@@ -258,7 +258,7 @@ class Model(object):
         """
         try:
             data = validate(self.__class__, self._data, partial=partial,
-                            strict=strict, meta=meta)
+                            strict=strict, env=env)
             self._data.update(**data)
         except BaseError as exc:
             raise ModelValidationError(exc.messages)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -236,12 +236,12 @@ class Model(object):
     __optionsclass__ = ModelOptions
 
     def __init__(self, raw_data=None, deserialize_mapping=None,
-                 partial=False, strict=True):
+                 partial=True, strict=True, meta=None):
         if raw_data is None:
             raw_data = {}
         self._initial = raw_data
         self._data = self.convert(raw_data, strict=strict, partial=partial,
-                                  mapping=deserialize_mapping)
+                                  mapping=deserialize_mapping, meta=meta)
 
     def validate(self, partial=False, strict=False, meta=None):
         """

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -11,9 +11,6 @@ from six import add_metaclass
 from .types import BaseType
 from .types.serializable import Serializable
 from .exceptions import BaseError, ModelValidationError, MockCreationError
-from .transforms import allow_none, atoms, flatten, expand
-from .transforms import to_primitive, to_native, convert
-from .validate import validate
 from .datastructures import OrderedDict as OrderedDictWithSort
 
 try:
@@ -430,3 +427,6 @@ class Model(object):
 
 
 from .types.compound import ModelType
+from .transforms import allow_none, atoms, flatten, expand
+from .transforms import to_primitive, to_native, convert
+from .validate import validate

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -235,13 +235,15 @@ class Model(object):
     #__metaclass__ = ModelMeta
     __optionsclass__ = ModelOptions
 
-    def __init__(self, raw_data=None, deserialize_mapping=None, strict=True):
+    def __init__(self, raw_data=None, deserialize_mapping=None,
+                 partial=False, strict=True):
         if raw_data is None:
             raw_data = {}
         self._initial = raw_data
-        self._data = self.convert(raw_data, strict=strict, mapping=deserialize_mapping)
+        self._data = self.convert(raw_data, strict=strict, partial=partial,
+                                  mapping=deserialize_mapping)
 
-    def validate(self, partial=False, strict=False):
+    def validate(self, partial=False, strict=False, meta=None):
         """
         Validates the state of the model and adding additional untrusted data
         as well. If the models is invalid, raises ValidationError with error
@@ -256,7 +258,7 @@ class Model(object):
         """
         try:
             data = validate(self.__class__, self._data, partial=partial,
-                            strict=strict)
+                            strict=strict, meta=meta)
             self._data.update(**data)
         except BaseError as exc:
             raise ModelValidationError(exc.messages)

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -71,9 +71,9 @@ def import_loop(cls, instance_or_dict, field_converter, context=None,
     # Determine all acceptable field input names
     all_fields = set(cls._fields) ^ set(cls._serializables)
     for field_name, field, in iteritems(cls._fields):
-        if hasattr(field, 'serialized_name'):
+        if field.serialized_name:
             all_fields.add(field.serialized_name)
-        if hasattr(field, 'deserialize_from'):
+        if field.deserialize_from:
             all_fields.update(set(_list_or_string(field.deserialize_from)))
         if field_name in meta.mapping:
             all_fields.update(set(_list_or_string(meta.mapping[field_name])))
@@ -86,10 +86,11 @@ def import_loop(cls, instance_or_dict, field_converter, context=None,
 
     for field_name, field in iteritems(cls._fields):
         serialized_field_name = field.serialized_name or field_name
-
         trial_keys = _list_or_string(field.deserialize_from)
-        trial_keys.extend(meta.mapping.get(field_name, []))
-        trial_keys.extend([serialized_field_name, field_name])
+        trial_keys.extend(_list_or_string(mapping.get(field_name, [])))
+        trial_keys.append(serialized_field_name)
+        if field_name != serialized_field_name:
+            trial_keys.append(field_name)
 
         raw_value = None
         for key in trial_keys:
@@ -389,8 +390,8 @@ def convert(cls, instance_or_dict, context=None, partial=True, strict=False,
             mapping=None, meta=None):
     def field_converter(field, value, meta=None):
         try:
-            return field.to_native(value, meta=meta)
-        except Exception:
+            return field.to_native(value, mapping=mapping)
+        except TypeError:
             return field.to_native(value)
 
     data = import_loop(cls, instance_or_dict, field_converter, context=context,

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -221,7 +221,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         else:
             return self.serialize_when_none
 
-    def validate(self, value, meta=None):
+    def validate(self, value):
         """
         Validate the field and return a clean value or raise a
         ``ValidationError`` with a list of errors raised by the validation
@@ -237,24 +237,23 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
                 validator(value)
             except ValidationError as exc:
                 errors.extend(exc.messages)
-
                 if isinstance(exc, StopValidation):
                     break
 
         if errors:
             raise ValidationError(errors)
 
-    # def validate_required(self, value):
-    #     if self.required and value is None:
-    #         raise ValidationError(self.messages['required'])
+    def validate_required(self, value, meta=None):
+        if self.required and value is None and not (meta and meta.get('partial')):
+            raise ValidationError(self.messages['required'])
 
-    def validate_choices(self, value):
+    def validate_choices(self, value, meta=None):
         if self.choices is not None:
             if value not in self.choices:
                 raise ValidationError(self.messages['choices']
                                       .format(unicode(self.choices)))
 
-    def mock(self, context=None):
+    def mock(self, context=None, meta=None):
         if not self.required and not random.choice([True, False]):
             return self.default
         if self.choices is not None:

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -243,17 +243,17 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         if errors:
             raise ValidationError(errors)
 
-    def validate_required(self, value, meta=None):
-        if self.required and value is None and not (meta and meta.get('partial')):
+    def validate_required(self, value, env=None):
+        if self.required and value is None and not (env and env.get('partial')):
             raise ValidationError(self.messages['required'])
 
-    def validate_choices(self, value, meta=None):
+    def validate_choices(self, value, env=None):
         if self.choices is not None:
             if value not in self.choices:
                 raise ValidationError(self.messages['choices']
                                       .format(unicode(self.choices)))
 
-    def mock(self, context=None, meta=None):
+    def mock(self, context=None, env=None):
         if not self.required and not random.choice([True, False]):
             return self.default
         if self.choices is not None:

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -221,7 +221,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         else:
             return self.serialize_when_none
 
-    def validate(self, value):
+    def validate(self, value, meta=None):
         """
         Validate the field and return a clean value or raise a
         ``ValidationError`` with a list of errors raised by the validation
@@ -244,9 +244,9 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         if errors:
             raise ValidationError(errors)
 
-    def validate_required(self, value):
-        if self.required and value is None:
-            raise ValidationError(self.messages['required'])
+    # def validate_required(self, value):
+    #     if self.required and value is None:
+    #         raise ValidationError(self.messages['required'])
 
     def validate_choices(self, value):
         if self.choices is not None:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -4,6 +4,7 @@ from __future__ import division
 
 from collections import Iterable
 import itertools
+import functools
 
 from ..exceptions import ValidationError, ConversionError, ModelValidationError, StopValidation
 from ..models import Model
@@ -16,7 +17,7 @@ from six import text_type as unicode
 
 class MultiType(BaseType):
 
-    def validate(self, value):
+    def validate(self, value, meta=None):
         """Report dictionary of errors with lists of errors as values of each
         key. Used by ModelType and ListType.
 
@@ -25,7 +26,10 @@ class MultiType(BaseType):
 
         for validator in self.validators:
             try:
-                validator(value)
+                try:
+                    validator(value, meta=meta)
+                except TypeError:
+                    validator(value)
             except ModelValidationError as exc:
                 errors.update(exc.messages)
             except StopValidation as exc:
@@ -65,8 +69,9 @@ class ModelType(MultiType):
         validators = kwargs.pop("validators", [])
         self.strict = kwargs.pop("strict", True)
 
-        def validate_model(model_instance):
-            model_instance.validate()
+        def validate_model(model_instance, meta=None):
+            print("ModelType here, calling validate() on model", model_class.__name__)
+            model_instance.validate(meta=meta)
             return model_instance
 
         super(ModelType, self).__init__(validators=[validate_model] + validators, **kwargs)
@@ -74,11 +79,10 @@ class ModelType(MultiType):
     def __repr__(self):
         return object.__repr__(self)[:-1] + ' for %s>' % self.model_class
 
-    def to_native(self, value, mapping=None, context=None):
+    def to_native(self, value, mapping=None, context=None, meta=None):
         # We have already checked if the field is required. If it is None it
         # should continue being None
-        if mapping is None:
-            mapping = {}
+        mapping = mapping or {}
         if value is None:
             return None
         if isinstance(value, self.model_class):
@@ -93,7 +97,7 @@ class ModelType(MultiType):
         # partial submodels now available with import_data (ht ryanolson)
         model = self.model_class()
         return model.import_data(value, mapping=mapping, context=context,
-                                 strict=self.strict)
+                                 strict=self.strict, meta=meta)
 
     def to_primitive(self, model_instance, context=None):
         primitive_data = {}
@@ -166,10 +170,14 @@ class ListType(MultiType):
         except TypeError:
             return [value]
 
-    def to_native(self, value, context=None):
+    def to_native(self, value, context=None, meta=None):
         items = self._force_list(value)
+        if isinstance(self.field, MultiType):
+            to_native = functools.partial(self.field.to_native, meta=meta)
+        else:
+            to_native = self.field.to_native
 
-        return [self.field.to_native(item, context) for item in items]
+        return [to_native(item, context) for item in items]
 
     def check_length(self, value):
         list_length = len(value) if value else 0
@@ -188,11 +196,11 @@ class ListType(MultiType):
             }[self.max_size == 1]) % self.max_size
             raise ValidationError(message)
 
-    def validate_items(self, items):
+    def validate_items(self, items, meta=None):
         errors = []
         for item in items:
             try:
-                self.field.validate(item)
+                self.field.validate(item, meta=meta)
             except ValidationError as exc:
                 errors += exc.messages
 
@@ -253,23 +261,26 @@ class DictType(MultiType):
     def model_class(self):
         return self.field.model_class
 
-    def to_native(self, value, safe=False, context=None):
+    def to_native(self, value, safe=False, context=None, meta=None):
         if value == EMPTY_DICT:
             value = {}
-
         value = value or {}
-
         if not isinstance(value, dict):
             raise ValidationError(u'Only dictionaries may be used in a DictType')
 
-        return dict((self.coerce_key(k), self.field.to_native(v, context))
+        if isinstance(self.field, MultiType):
+            to_native = functools.partial(self.field.to_native, meta=meta)
+        else:
+            to_native = self.field.to_native
+
+        return dict((self.coerce_key(k), to_native(v, context))
                     for k, v in iteritems(value))
 
-    def validate_items(self, items):
+    def validate_items(self, items, meta=None):
         errors = {}
         for key, value in iteritems(items):
             try:
-                self.field.validate(value)
+                self.field.validate(value, meta=meta)
             except ValidationError as exc:
                 errors[key] = exc
 

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -3,7 +3,7 @@ from .transforms import import_loop
 from .types.compound import MultiType
 
 
-def validate(cls, instance_or_dict, partial=False, strict=False, context=None, meta=None):
+def validate(cls, instance_or_dict, partial=False, strict=False, context=None, env=None):
     """
     Validate some untrusted data using a model. Trusted data can be passed in
     the `context` parameter.
@@ -31,10 +31,10 @@ def validate(cls, instance_or_dict, partial=False, strict=False, context=None, m
     errors = {}
 
     # Function for validating an individual field
-    def field_converter(field, value, meta=None):
+    def field_converter(field, value, env=None):
         if isinstance(field, MultiType):
-            value = field.to_native(value, meta=meta)
-            field.validate(value, meta=meta)
+            value = field.to_native(value, env=env)
+            field.validate(value, env=env)
         else:
             value = field.to_native(value)
             field.validate(value)
@@ -43,7 +43,7 @@ def validate(cls, instance_or_dict, partial=False, strict=False, context=None, m
     # Loop across fields and coerce values
     try:
         data = import_loop(cls, instance_or_dict, field_converter,
-                           context=context, partial=partial, strict=strict, meta=meta)
+                           context=context, partial=partial, strict=strict, env=env)
     except ModelConversionError as mce:
         errors = mce.messages
 

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -186,7 +186,7 @@ def test_list_model_field():
 
 
 def test_stop_validation():
-    def raiser(x):
+    def raiser(*args, **kwargs):
         raise StopValidation({'something': 'bad'})
 
     lst = ListType(StringType(), validators=[raiser])

--- a/tests/test_recursive_import.py
+++ b/tests/test_recursive_import.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from schematics.models import Model
+from schematics.types import BaseType, IntType, StringType
+from schematics.types.compound import ListType, DictType, ModelType
+from schematics.exceptions import ModelConversionError, ModelValidationError
+
+def test_nested_mapping():
+
+    mapping = {
+        'model_mapping': {
+            'modelfield': {
+                'subfield': 'importfield'
+            }
+        }
+    }
+
+    class SubModel(Model):
+        subfield = StringType()
+
+    class MainModel(Model):
+        modelfield = ModelType(SubModel)
+
+    m1 = MainModel({
+        'modelfield': {'importfield':'qweasd'},
+        }, deserialize_mapping=mapping)
+
+    assert m1.modelfield.subfield == 'qweasd'
+
+def test_nested_mapping_with_required():
+
+    mapping = {
+        'model_mapping': {
+            'modelfield': {
+                'subfield': 'importfield'
+            }
+        }
+    }
+
+    class SubModel(Model):
+        subfield = StringType(required=True)
+
+    class MainModel(Model):
+        modelfield = ModelType(SubModel)
+
+    m1 = MainModel({ # Note partial=False here!
+        'modelfield': {'importfield':'qweasd'},
+        }, partial=False, deserialize_mapping=mapping)
+
+def test_submodel_required_field():
+
+    class SubModel(Model):
+        subfield1 = StringType(required=True)
+        subfield2 = StringType()
+
+    class MainModel(Model):
+        intfield = IntType()
+        stringfield = StringType()
+        modelfield = ModelType(SubModel)
+
+    # By default, model instantiation assumes partial=True
+    m1 = MainModel({
+        'modelfield': {'subfield2':'qweasd'}})
+
+    with pytest.raises(ModelConversionError):
+        m1 = MainModel({
+            'modelfield': {'subfield2':'qweasd'}}, partial=False)
+
+    # Validation implies partial=False
+    with pytest.raises(ModelValidationError):
+        m1.validate()
+
+    m1.validate(partial=True)
+


### PR DESCRIPTION
#### Summary

This patch introduces a metadata object that is propagated through every level of a recursive import/validation process. It is used to carry options and other data that need to be available throughout the entire process, not just during the outermost loop.

#### Background

One thing currently blocking the `Undefined` feature is the fact that import/validation parameters (importantly, `partial=True`) only affect the first level of processing. If you have nested models, your settings no longer apply.

Apparently someone has noticed this before and created this construct in `import_loop` to pass the deserialization mapping down to nested models:

```python
try:
    ...
    raw_value = field_converter(field, raw_value, mapping=model_mapping)
except Exception:
    raw_value = field_converter(field, raw_value)
```

And there was a similar `try—except` inside the `field_converter` in question.

#### The patch

**EDIT:** Changed param name from `meta` to `env`.

Instead of adding yet another parameter here, I have future-proofed this by turning the third parameter into a multipurpose object representing the current environment. Import converters and validators can now propagate options and whatever data they please in the `env` parameter. One practical application might be bookkeeping during validation; currently it's possible to have a `ModelType` structure that gets into an infinite loop.

The above code now looks like this:

```python
    sub_env = env.copy() # Make a copy
    sub_env.mapping = model_mapping  # Put the relevant mapping in there
    raw_value = field_converter(field, raw_value, env=sub_env) # Pass it on
```

The way this works is any function (including the initial caller) could decide to set up the `Environment` object. Once it enters the processing chain, its contents override any overlapping parameters passed as keyword args (EDIT: not by necessity, of course, but because `import_loop` chooses to treat it that way).

Right now, the setup is the responsibility of the outermost `import_loop`. It takes the `strict` and `partial` arguments it receives and locks them in for the rest of the import recursion.

As an aside, if all options were collated into a `env` object from the start, the parameter signature of `import_loop`, `convert`, and friends could look like this:

```python
def ...(cls, instance_or_dict, env)
```

Although incorporating many options into a single object may be considered a bit opaque, it's clearly preferable to always passing a dozen values to every method and their aunts:

```python
model.validate(...)
=> validate(...)
=> import_loop(...)
=> field_converter(...)
=> field.validate(...)
=> submodel.validate(...)
```

That's five calls for each level of recursion.

#### BREAKING CHANGE WARNING

I've gotten rid of the `try–except` constructs that otherwise would have been all over the place.

Considering that the `env` container is primarily needed in a recursive process, the method signature dilemma has been solved by requiring *compound types* (`MultiType` descendants) to accept the `env` argument in their `to_native` and `validate_` methods. Simple types are called without `env`.

Since custom compound types need a (trivial) change as a result, this would be a great opportunity also to get rid of the `context` parameter that appears in a ton of places. It would be better placed inside `env` as well.

#### Other changes incorporated here

* `Model.__init__` now accepts the `partial` parameter too (default=`True` because it was the de facto default already, specified in the main `convert` func).

* Fixed a bug where `ListType.validate_items()` was added to the list of validators twice: once explicitly and once via collation by `TypeMeta`.
