### PR TITLE
Marshallers and extended serializables for better data manipulation at import/export time

### DIFF
--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -1,4 +1,3 @@
-
 from schematics.types.base import BaseType
 
 
@@ -23,12 +22,9 @@ def serializable(*args, **kwargs):
     :param serialized_name:
         The name of this field in the serialized output.
     """
-    def wrapper(func):
-        serialized_type = kwargs.pop("type", BaseType())  # pylint: disable=no-value-for-parameter
-        serialized_name = kwargs.pop("serialized_name", None)
-        serialize_when_none = kwargs.pop("serialize_when_none", True)
-        return Serializable(func, type=serialized_type, serialized_name=serialized_name,
-                            serialize_when_none=serialize_when_none)
+    def wrapper(func_or_cls):
+        kwargs['serialized_type'] = kwargs.pop("type", BaseType()) # pylint: disable=no-value-for-parameter
+        return Serializable(func_or_cls, **kwargs)
 
     if len(args) == 1 and callable(args[0]):
         # No arguments, this is the decorator
@@ -40,17 +36,33 @@ def serializable(*args, **kwargs):
 
 class Serializable(object):
 
-    def __init__(self, func, type=None, serialized_name=None, serialize_when_none=True):
-        self.func = func
-        self.type = type
+    MESSAGES = {
+        'required': u"This field is required.",
+    }
+
+    def __init__(self, func_or_cls, 
+                 required=False,
+                 default=None,
+                 serialized_type=None, 
+                 serialized_name=None, 
+                 deserialize_from=None,
+                 serialize_when_none=None):
+        self.serialize = func_or_cls.__dict__.get('serialize', func_or_cls)
+        self.deserialize = func_or_cls.__dict__.get('deserialize', None)
+        self.required = required
+        self.default = default
+        self.type = serialized_type
         self.serialized_name = serialized_name
+        self.deserialize_from = deserialize_from
         self.serialize_when_none = serialize_when_none
+        self.messages = self.MESSAGES
 
     def __get__(self, instance, cls):
-        return self.func(instance)
+        return self.serialize(instance)
 
     def to_native(self, value, context=None):
         return self.type.to_native(value, context)
 
     def to_primitive(self, value, context=None):
         return self.type.to_primitive(value, context)
+

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from schematics.exceptions import ModelConversionError
+from schematics.models import Model
+from schematics.types import StringType, LongType, IntType, MD5Type
+from schematics.types.compound import ModelType, DictType, ListType
+from schematics.types.serializable import serializable
+from schematics.transforms import blacklist, whitelist, wholelist, export_loop
+
+import six
+from six import iteritems
+try:
+    unicode #PY2
+except:
+    import codecs
+    unicode = str #PY3
+
+
+def test_marshaller():
+
+    class Person(Model):
+
+        first_name = StringType()
+        last_name = StringType()
+        testfield = StringType(default='aaa')
+
+        def marshal(cls, data):
+            del data['testfield']
+
+        def marshal_full_name(cls, data):
+            new_data = {
+                'full_name': '%s %s' % (data['first_name'], data['last_name'])
+            }
+            return (new_data, ('first_name', 'last_name'))
+
+        def unmarshal_full_name(cls, data):
+            if 'full_name' not in data:
+                raise ModelConversionError("Field 'full_name' missing") 
+            first_name, last_name = data['full_name'].split()
+            new_data = {
+                'first_name': first_name, 
+                'last_name': last_name
+            }
+            return (new_data, ('full_name',))
+
+    with pytest.raises(ModelConversionError):
+        person = Person()
+
+    person = Person({'full_name': 'First Last'})
+    assert person._data == dict(first_name='First', last_name='Last', testfield='aaa')
+
+    person.validate()
+
+    assert person.to_primitive() == dict(full_name='First Last')
+


### PR DESCRIPTION
The `serializable` decorator currently provides a simple way for a model to expose a virtual field. However, the mechanism doesn't handle two-way communication.

Consider a model with fields `first_name` and `last_name` that needs to talk to a client that only sends and receives a single value, `full_name`:

``` python
class Person(Model):

    first_name = StringType()
    last_name = StringType()

    @serializable
    def full_name(self):
        return '%s %s' % (self.first_name, self.last_name)
```

The above works for outbound data, but what about the reverse? How to split the incoming value into two concrete fields?

This PR introduces two facilities that provide pre- and post-processing hooks for data manipulation.
### Extended serializables

Instead of decorating a function, decorate a class that encloses functions for both exporting and importing:

``` python
    @serializable
    class full_name:

        def serialize(self):
            return '%s %s' % (self.first_name, self.last_name)

        def deserialize(value):
            first_name, last_name = value.split()
            return {
                'first_name': first_name, 
                'last_name': last_name
            }
```

The wrapper class (`full_name`) is nothing but a closure. It will never be instantiated, and inside the `serialize` function `self` still refers to the `Person` instance. In other words, `serialize()` here is identical to the classic one-way serializable.

The dictionary returned by `deserialize()` will be added to the dataset, and the original incoming field (`full_name`) will be automatically discarded.
### Marshalling/unmarshalling functions

These are functions that can perform arbitrary operations on the entire dataset.

``` python
class Person(Model):

    first_name = StringType()
    last_name = StringType()

    def marshal_full_name(cls, data):
        data['full_name'] = '%s %s' % (data['first_name'], data['last_name'])

    def unmarshal_full_name(cls, data):
        if 'full_name' not in data:
            raise ModelConversionError("Field 'full_name' missing") 
        first_name, last_name = data['full_name'].split()
        new_data = {
            'first_name': first_name, 
            'last_name': last_name
        }
        return (new_data, ('full_name',))
```

An **unmarshaller** (processes inbound data) must return a tuple with two items:
- a dictionary that will be added to the dataset
- an iterable of keys that should be discarded (nothing is dropped automatically).

A **marshaller** (processes outbound data) may do the same, or it can modify the dataset directly and return nothing, as shown above.

Apart from the `(un)marshal_` prefix, the names of the functions are of no consequence (except for error info), since they do not necessarily relate to just a single field. A model-wide pre/post-processor can be named simply `unmarshal` or `marshal`.
### Comparison
- Serializables deal with native values: they are invoked after `to_native()` upon import and before `to_primitive()` upon export.
- Marshalling functions deal with primitive values: they are called before `to_native()` upon import and after `to_primitive()` upon export.
- Serializables always map to **one** exposed field. If you wanted to do the opposite of the example and map multiple incoming values to a single concrete field, a serializable will not do.
- Marshalling is more powerful, since the entire dataset can be freely manipulated.
- The unmarshallers are run before anything else is done to the incoming data. For example, multiple values may be coalesced into one, and the surplus transport fields can be dropped before rogue fields are checked for.
- A serializable is always available as `instance.some_serializable`, whereas marshallers are only evaluated at export time.
### Also changed

Serializables now accept the parameters `default`, `required`, and `deserialize_from`. Note that `required` on a serializable is only enforced on import — not during validation.

The default value for `serialize_when_none` on serializables now matches that on types (changed from `True` to `None`).
