### PR TITLE
switch to versioning scheme to 'x.y.z'

### DIFF
--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -1,4 +1,4 @@
 
 version_info = ('1', '0', '0')
 
-__version__ = '{0}.{1}-{2}'.format(*version_info)
+__version__ = '{0}.{1}.{2}'.format(*version_info)


### PR DESCRIPTION
Now with PEP-440, _x.y-z_ is considered a post-release of _x.y_, and parsed as _x.y.post1_ by setuptools and pip.
Post-releases are intended to _address minor errors in a final release that do not affect the distributed software_.

Sound like you guys should just use _x.y.z_ and release plain, final releases.