### PR TITLE
Update Model.__eq__

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,3 +5,4 @@ python-dateutil==2.2
 pymongo==2.7.1
 ordereddict==1.1
 tox==1.8
+mock==1.0.1

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -407,7 +407,7 @@ class Model(object):
                 if self.get(k) != other.get(k):
                     return False
             return True
-        return False
+        return NotImplemented
 
     def __ne__(self, other):
         return not self == other

--- a/tests/test_equality.py
+++ b/tests/test_equality.py
@@ -1,0 +1,11 @@
+import mock
+
+from schematics.models import Model
+
+
+class TestModel(Model):
+    pass
+
+
+def test_equality_against_mock_any():
+    assert TestModel() == mock.ANY


### PR DESCRIPTION
* Model.__eq__ now returns NotImplemented if the other object is not the
  same class.  This allows the other objects __eq__ to be checked.  This
  is particularly important for testing (e.g. mock.Any, equals).