### PR TITLE
Release 1.0.2

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,7 @@
+1.0.2 / 2015-02-12
+==================
+* [Bug](`#280 https://github.com/schematics/schematics/issues/280`_) Fix the circular import issue.
+
 1.0.1 / 2015-02-01
 ==================
 * [Bug](`#252 <https://github.com/schematics/schematics/pull/252>`_) Fixed project URL
@@ -17,7 +21,7 @@
 ==================
 
 * [Feature] (`#191 <https://github.com/schematics/schematics/pull/191>`_) Updated import_data to avoid overwriting existing data. deserialize_mapping can now support partial and nested models.
-* [Documentation] (`#192 <https://github.com/schematics/schematics/pull/192>`_) Document the creation of custom types 
+* [Documentation] (`#192 <https://github.com/schematics/schematics/pull/192>`_) Document the creation of custom types
 * [Feature] (`#193 <https://github.com/schematics/schematics/pull/193>`_) Add primitive types accepting values of any simple or compound primitive JSON type.
 * [Bug] (`#194 <https://github.com/schematics/schematics/pull/194>`_) Change standard coerce_key function to unicode
 * [Tests] (`#196 <https://github.com/schematics/schematics/pull/196>`_) Test fixes and cleanup
@@ -25,7 +29,7 @@
 * [Bug] (`#198 <https://github.com/schematics/schematics/pull/198>`_) Fixed typo in variable name in DateTimeType
 * [Feature] (`#200 <https://github.com/schematics/schematics/pull/200>`_) Added the option to turn of strict conversion when creating a Model from a dict
 * [Feature] (`#212 <https://github.com/schematics/schematics/pull/212>`_) Support exporting ModelType fields with subclassed model instances
-* [Feature] (`#214 <https://github.com/schematics/schematics/pull/214>`_) Create mock objects using a class's fields as a template 
+* [Feature] (`#214 <https://github.com/schematics/schematics/pull/214>`_) Create mock objects using a class's fields as a template
 * [Bug] (`#215 <https://github.com/schematics/schematics/pull/215>`_) PEP 8 FTW
 * [Feature] (`#216 <https://github.com/schematics/schematics/pull/216>`_) Datastructures cleanup
 * [Feature] (`#217 <https://github.com/schematics/schematics/pull/217>`_) Models cleanup pt 1
@@ -71,6 +75,3 @@
 * [Feature] Renamed ``check_value`` to ``validate_range``
 * [Feature] Changed ``serialize`` to ``to_native``
 * [Bug] (`#155 <https://github.com/schematics/schematics/pull/155>`_) NumberType number range validation bugfix
-
-
-

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,7 @@
 * [Bug](`#252 <https://github.com/schematics/schematics/pull/252>`_) Fixed project URL
 * [Feature] (`#259 <https://github.com/schematics/schematics/pull/259>`_) Give export loop to serializable when type has one
 * [Feature] (`#262 <https://github.com/schematics/schematics/pull/262>`_) Make copies of inherited meta attributes when setting up a Model
+* [Documentation] (`#276 <https://github.com/schematics/schematics/pull/276>`_) Improve the documentation of get_mock_object
 
 1.0.0 / 2014-10-16
 ==================

--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 version_info = ('1', '0', '1')
 
 __version__ = '{0}.{1}.{2}'.format(*version_info)

--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -1,4 +1,3 @@
-
 version_info = ('1', '0', '1')
 
-__version__ = '{0}.{1}-{2}'.format(*version_info)
+__version__ = '{0}.{1}.{2}'.format(*version_info)

--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-version_info = ('1', '0', '1')
+version_info = ('1', '0', '2')
 
 __version__ = '{0}.{1}.{2}'.format(*version_info)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -61,6 +61,7 @@ class FieldDescriptor(object):
         """
         Checks the field name against a model and sets the value.
         """
+        from .types.compound import ModelType
         field = instance._fields[self.name]
         if not isinstance(value, Model) and isinstance(field, ModelType):
             value = field.model_class(value)
@@ -430,6 +431,3 @@ class Model(object):
 
     def __unicode__(self):
         return '%s object' % self.__class__.__name__
-
-
-from .types.compound import ModelType


### PR DESCRIPTION
- Fixes #279.
- Use x.y.z as said per https://github.com/schematics/schematics/pull/273