### PR TITLE
Add missing requirement for `six`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,8 @@ setup(
     cmdclass={
         'test': Tox,
     },
+    install_requires=[
+        'six>=1.7.3',
+    ],
     tests_require=tests_require,
 )

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,10 +1,17 @@
 import pytest
-from bson.objectid import ObjectId
 
-from schematics.contrib.mongo import ObjectIdType
-from schematics.exceptions import ConversionError, ValidationError
+try:
+    from bson.objectid import ObjectId
+except ImportError:
+    ObjectId = None
+else:
+    from schematics.contrib.mongo import ObjectIdType
+    from schematics.exceptions import ConversionError, ValidationError
 
-FAKE_OID = ObjectId()
+    FAKE_OID = ObjectId()
+
+pytestmark = pytest.mark.skipif(ObjectId is None,
+                                reason='requires pymongo')
 
 
 def test_to_native():

--- a/tests/test_temporal.py
+++ b/tests/test_temporal.py
@@ -1,10 +1,18 @@
 from datetime import datetime
 
-from dateutil.tz import gettz, tzutc
+import pytest
 
-from schematics.types.temporal import TimeStampType
+try:
+    from dateutil.tz import gettz, tzutc
+except ImportError:
+    gettz = tzutc = None
+else:
+    from schematics.types.temporal import TimeStampType
 
-EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=tzutc())
+    EPOCH = datetime(1970, 1, 1, 0, 0, tzinfo=tzutc())
+
+pytestmark = pytest.mark.skipif(tzutc is None,
+                                reason='requires python-dateutil')
 
 
 def test_timezone_to_date():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=py26,py27,py33,py34
+envlist=py26,py27,py27-minimal-reqs,py33,py34,py34-minimal-reqs
 indexserver=
     pypi = https://pypi.python.org/simple
 
@@ -8,6 +8,14 @@ indexserver=
 commands= coverage run --source schematics -m py.test
           coverage report
 deps = -r{toxinidir}/requirements-testing.txt
+
+[testenv:py27-minimal-reqs]
+commands = py.test
+deps = pytest
+
+[testenv:py34-minimal-reqs]
+commands = py.test
+deps = pytest
 
 [pytest]
 addopts=tests


### PR DESCRIPTION
I started using Schematics on a project today, and was surprised to see my app immediately exit with `ImportError: No module named six`. It looks like commit 0782c36eeb1232c45fa678c0aa548ca96e96b356 started using [six][six] in Schematics, but it was never added to `install_requires` in `setup.py`.

This is not currently caught in Travis because tests install python-coveralls, which [itself requires six][cover-six]. So, this pull request (1) add a requirement for six, and (2) adds new Tox environments that will run unit tests with only `py.test` additionally installed to catch this kind of error.

[six]: https://pypi.python.org/pypi/six
[cover-six]: https://github.com/z4r/python-coveralls/blob/dc05431c7c3d30ba6c7ce486421240a062e47e68/requirements.txt#L4