### PR TITLE
Add parameter to pass in a list of Role names

### DIFF
--- a/docs/usage/exporting.rst
+++ b/docs/usage/exporting.rst
@@ -312,6 +312,44 @@ results without having to specify ``role`` in the export function.
       }]
   }
 
+Optionally a list of roles can be provided for export instead. The combination
+of the all the roles will be made and used to filter fields. Blacklist roles
+override whitelist roles in this case.
+
+::
+
+    class User(Model):
+        id = IntType(default=42)
+        name = StringType()
+        email = StringType()
+        password = StringType()
+
+        class Options:
+            roles = {
+                'public': whitelist('id', 'name', 'email'),
+                'admin': whitelist('password')
+                'no_private': blacklist('password', 'email')
+            }
+
+The ``password`` field will combined with the ``id``, ``name`` and ``email``
+fields when ``roles`` is set to both ``public`` and ``admin``.
+
+ >>> favorites.to_primitive(roles=['public', 'admin'])
+  {
+      'id': 42,
+      'name': 'Arthur',
+      'email': 'adent@hitchhiker.gal',
+      'password': 'dolphins'
+  }
+
+Adding in the ``no_private`` role will then blacklist the ``email`` and
+``password`` fields.
+
+ >>> favorites.to_primitive(roles=['public', 'admin', 'no_private'])
+  {
+      'id': 42,
+      'name': 'Arthur'
+  }
 
 
 .. _exporting_serializable:

--- a/docs/usage/exporting.rst
+++ b/docs/usage/exporting.rst
@@ -334,7 +334,7 @@ override whitelist roles in this case.
 The ``password`` field will combined with the ``id``, ``name`` and ``email``
 fields when ``roles`` is set to both ``public`` and ``admin``.
 
- >>> favorites.to_primitive(roles=['public', 'admin'])
+ >>> user.to_primitive(roles=['public', 'admin'])
   {
       'id': 42,
       'name': 'Arthur',
@@ -345,7 +345,7 @@ fields when ``roles`` is set to both ``public`` and ``admin``.
 Adding in the ``no_private`` role will then blacklist the ``email`` and
 ``password`` fields.
 
- >>> favorites.to_primitive(roles=['public', 'admin', 'no_private'])
+ >>> user.to_primitive(roles=['public', 'admin', 'no_private'])
   {
       'id': 42,
       'name': 'Arthur'

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -292,7 +292,7 @@ class Model(object):
     def to_native(self, role=None, context=None):
         return to_native(self.__class__, self, role=role, context=context)
 
-    def to_primitive(self, role=None, context=None):
+    def to_primitive(self, role=None, context=None, roles=None):
         """Return data as it would be validated. No filtering of output unless
         role is defined.
 
@@ -300,10 +300,10 @@ class Model(object):
             Filter output by a specific role
 
         """
-        return to_primitive(self.__class__, self, role=role, context=context)
+        return to_primitive(self.__class__, self, role=role, context=context, roles=roles)
 
-    def serialize(self, role=None, context=None):
-        return self.to_primitive(role=role, context=context)
+    def serialize(self, role=None, context=None, roles=None):
+        return self.to_primitive(role=role, context=context, roles=roles)
 
     def flatten(self, role=None, prefix=""):
         """

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -978,3 +978,11 @@ def test_multiple_roles():
         user.serialize(roles=['public', 'create', 'NOT_A_ROLE'])
     except ValueError as ve:
         assert ve.message == 'User Model has no role "NOT_A_ROLE"'
+
+    d = user.to_primitive(roles=['public', 'create', 'no_private'])
+
+    assert d == {
+        'id': 42,
+        'name': 'Arthur'
+    }
+


### PR DESCRIPTION
This provides a simpler method to combine multiple roles on export. Given a simple list of roles, when export is called a list of roles can be provided and the export will combine the roles and filter fields appropriately. Therefore dynamic role combination is available. Blacklist roles will override whitelist roles.
