### PR TITLE
Support for fields order in serialized format via Options class in model

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -86,7 +86,7 @@ class ModelOptions(object):
     """
 
     def __init__(self, klass, namespace=None, roles=None,
-                 serialize_when_none=True):
+                 serialize_when_none=True, fields_order=None):
         """
         :param klass:
             The class which this options instance belongs to.
@@ -98,11 +98,15 @@ class ModelOptions(object):
         :param serialize_when_none:
             When ``False``, serialization skips fields that are None.
             Default: ``True``
+        :param fields_order:
+            List of field names that dictates in which order will keys
+            appear in serialized dictionary.
         """
         self.klass = klass
         self.namespace = namespace
         self.roles = roles or {}
         self.serialize_when_none = serialize_when_none
+        self.fields_order = fields_order
 
 
 class ModelMeta(type):

--- a/tests/test_ordered_serialization.py
+++ b/tests/test_ordered_serialization.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from schematics.datastructures import OrderedDict
+from schematics.models import Model
+from schematics.types import StringType, IntType
+
+
+def test_serialize_field_orders_one_two_three():
+    class Example(Model):
+        one = StringType()
+        two = IntType()
+        three = StringType()
+
+        class Options:
+            fields_order = ['one', 'two', 'three']
+
+    p1 = Example({'one': 'a', 'two': 2, 'three': '3'})
+    order = [('one', 'a'), ('two', 2), ('three', '3')]
+    serialized = p1.to_native()
+    assert serialized.items() == order
+
+
+def test_serialize_field_orders_three_two_one():
+    class Example(Model):
+        one = StringType()
+        two = IntType()
+        three = StringType()
+
+        class Options:
+            fields_order = ['three', 'two', 'one']
+
+    p1 = Example({'one': 'a', 'two': 2, 'three': '3'})
+    serialized = p1.to_native()
+    order = [('three', '3'), ('two', 2), ('one', 'a')]
+    assert serialized.items() == order
+
+
+def test_serialize_field_orders_one_three_two():
+    class Example(Model):
+        one = StringType()
+        two = IntType()
+        three = StringType()
+
+        class Options:
+            fields_order = ['one', 'three', 'two']
+
+    p1 = Example({'one': 'a', 'two': 2, 'three': '3'})
+    serialized = p1.to_native()
+    order = [('one', 'a'), ('three', '3'), ('two', 2)]
+    assert serialized.items() == order


### PR DESCRIPTION
I have implemented simple way of declaring order of fields in serialized output. 
Something like this does not have great technical value, but it is nice to return dictionary always in the same format when using schematics as validation layer for REST API (which is the way that I am using it).

This might not be the best way to implement this, but it reflects just the thing that I need. 

I was not sure what to do with fields that are not specified in `fields_order` list, so I did nothing and in that case order of fields is not guaranteed in any way, just as it is not guaranteed with `dict` (well, fields that are mentioned in `fields_order` will be pushed back, other fields will be left in front, but that is just a side effect).

What do you think?

I am opened to suggestions, if you have any.