### PR TITLE
fix ListType, validate_items adds to errors list just field name without...

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -194,8 +194,7 @@ class ListType(MultiType):
             try:
                 self.field.validate(item)
             except ValidationError as exc:
-                errors += exc.messages
-
+                errors.append(exc.messages)
         if errors:
             raise ValidationError(errors)
 

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -185,6 +185,20 @@ def test_list_model_field():
     assert errors['users'] == [u'This field is required.']
 
 
+def test_list_model_field_exception_with_full_message():
+    class User(Model):
+        name = StringType(max_length=1)
+
+    class Group(Model):
+        users = ListType(ModelType(User))
+
+    g = Group({'users': [{'name': "ToLongName"}]})
+
+    with pytest.raises(ValidationError) as exception:
+        g.validate()
+    assert exception.value.messages == {'users': [{'name': ['String value is too long.']}]}
+
+
 def test_stop_validation():
     def raiser(x):
         raise StopValidation({'something': 'bad'})


### PR DESCRIPTION
I discovered it while I was trying to create a list of models with custom type fields validators. 
Result was: I couldn't retrieve my custom error message with model field value.


Whole issue occures because of  casting  dic to list with += operator (errors += exc.messages)

Simple example: 
d = []
d += {'a': 'b', 'c':'d'}
dic is casted to list of dic keys  ['a', 'c']

append solves the problem of missing valdation exception message 


before fix messege was:  {'users': [{'name'}]}
afret fix message is: {'users': [{'name': ['String value is too long.']}]}


