### PR TITLE
Include Partial Data when Raising ModelConversionError

### DIFF
--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -35,7 +35,9 @@ class ConversionError(BaseError, TypeError):
 
 
 class ModelConversionError(ConversionError):
-    pass
+    def __init__(self, messages, partial_data=None):
+        super(ModelConversionError, self).__init__(messages)
+        self.partial_data = partial_data
 
 
 class ValidationError(BaseError, ValueError):

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -116,7 +116,7 @@ def import_loop(cls, instance_or_dict, field_converter, context=None,
             errors[serialized_field_name] = exc.messages
 
     if errors:
-        raise ModelConversionError(errors)
+        raise ModelConversionError(errors, data)
 
     return data
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -161,6 +161,23 @@ def test_returns_nice_conversion_errors():
         }
 
 
+def test_returns_partial_data_with_conversion_errors():
+    class User(Model):
+        name = StringType(required=True)
+        age = IntType(required=True)
+        account_level = IntType()
+
+    with pytest.raises(ModelConversionError) as exception:
+        User({"name": "Jóhann", "age": "100 years", "account_level": "3"})
+
+    partial_data = exception.value.partial_data
+
+    assert partial_data == {
+        "name": u"Jóhann",
+        "account_level": 3,
+    }
+
+
 def test_field_default():
     class User(Model):
         name = StringType(default=u'Doggy')


### PR DESCRIPTION
Schematics already has excellent separation of data parsing and validation. This PR adds the ability to access the result of converting primitive data in case of ModelConversionError.

`import_loop` is the central mechanism for converting primitive values to native Python objects. If it encounters a conversion error when working on one field, the `import_loop` catches and stores and the error and moves on to the next field instead of bailing out completely on the first error. By the end of the `import_loop`, it has all the partial data parsed based on best effort in addition to all errors encountered. However, ModelConversionError only exposes the errors. This PR makes parsing result accessible as well through ModelConversionError.

Specifically, ModelConversionError is updated to have a `partial_data` (optional) attribute. Interested party could catch the exception and access the attribute to retrieve the parsing result. Existing code that has no interest in this attribute requires no change at all.

This feature is very handy in implementing a "best effort" parsing, which in turn is useful in building system that acts in response to user intention rather than fully validated user data. For example, in a user sign up form, the phone number field being malformed should not prevent the application from parsing the "zip code" field and auto-selects proper value for the "state" field.