### PR TITLE
improves date_time_type error message for custom formats

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -14,10 +14,10 @@ from ..exceptions import (
     StopValidation, ValidationError, ConversionError, MockCreationError
 )
 
-try: 
+try:
     from string import ascii_letters # PY3
 except ImportError:
-    from string import letters as ascii_letters #PY2 
+    from string import letters as ascii_letters #PY2
 
 try:
     basestring #PY2
@@ -506,7 +506,7 @@ class LongType(NumberType):
             number_class = long #PY2
         except NameError:
             number_class = int #PY3
-        
+
 
         super(LongType, self).__init__(number_class=number_class,
                                        number_type='Long',
@@ -689,6 +689,7 @@ class DateTimeType(BaseType):
 
     MESSAGES = {
         'parse': u'Could not parse {0}. Should be ISO8601.',
+        'parse_formats': u'Could not parse {0}. Valid formats: {1}',
     }
 
     def __init__(self, formats=None, serialized_format=None, **kwargs):
@@ -725,7 +726,13 @@ class DateTimeType(BaseType):
                 return datetime.datetime.strptime(value, fmt)
             except (ValueError, TypeError):
                 continue
-        raise ConversionError(self.messages['parse'].format(value))
+        if self.formats == self.DEFAULT_FORMATS:
+            message = self.messages['parse'].format(value)
+        else:
+            message = self.messages['parse_formats'].format(
+                value, ", ".join(self.formats)
+            )
+        raise ConversionError(message)
 
     def to_primitive(self, value, context=None):
         if callable(self.serialized_format):


### PR DESCRIPTION
A very small pull request to improve the parsing error message for `DateTimeType` with custom formats.

Reason: If you build a (distributed) API with a DateTimeType you may get hard to debug errors for custom formats.