### PR TITLE
accept optional 'Z' suffix for UTC date_time_type format

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -14,10 +14,10 @@ from ..exceptions import (
     StopValidation, ValidationError, ConversionError, MockCreationError
 )
 
-try: 
+try:
     from string import ascii_letters # PY3
 except ImportError:
-    from string import letters as ascii_letters #PY2 
+    from string import letters as ascii_letters #PY2
 
 try:
     basestring #PY2
@@ -506,7 +506,7 @@ class LongType(NumberType):
             number_class = long #PY2
         except NameError:
             number_class = int #PY3
-        
+
 
         super(LongType, self).__init__(number_class=number_class,
                                        number_type='Long',
@@ -678,13 +678,17 @@ class DateTimeType(BaseType):
 
     :param formats:
         A value or list of values suitable for ``datetime.datetime.strptime``
-        parsing. Default: `('%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%S')`
+        parsing. Default: `('%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%S',
+        '%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ')`
     :param serialized_format:
         The output format suitable for Python ``strftime``. Default: ``'%Y-%m-%dT%H:%M:%S.%f'``
 
     """
 
-    DEFAULT_FORMATS = ('%Y-%m-%dT%H:%M:%S.%f', '%Y-%m-%dT%H:%M:%S')
+    DEFAULT_FORMATS = (
+        '%Y-%m-%dT%H:%M:%S.%f',  '%Y-%m-%dT%H:%M:%S',
+        '%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ',
+    )
     SERIALIZED_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
     MESSAGES = {


### PR DESCRIPTION
The schematics DateTimeType does not yet accept timezones but implicitly takes the string as UTC. It should or could also accept date strings that explicitly state UTC by 'Z' suffix. 

Side advantage: the default format given by i.e. JavaScript's isoformat()-method (and some other ISO8601-compliant libraries that use to convert to UTC xmlschema) will be accepted out of the box.

This is a best effort approach. To handle timezones will be platform dependent, introduce dependencies (dateutils) or require additional work until strptime's %z (python 3.3 ... ) can be used. However, if you work with UTC+UTC based libraries and as the date is perceived as UTC anyway, it seems counter intuitive having to configure this every time.