### PR TITLE
Update Model to accept kwargs to its constructor as initial field values. These will override dict raw_data values with same key.

### DIFF
--- a/docs/usage/models.rst
+++ b/docs/usage/models.rst
@@ -44,6 +44,13 @@ And remember that ``DateTimeType`` we set a default callable for?
   >>> wr.taken_at
   datetime.datetime(2013, 8, 21, 13, 6, 38, 11883)
 
+We can also initialize a model using keyword arguments to its constructor.
+
+::
+  >>> wr = WeatherReport(city='NYC', temperature=80)
+  >>> wr.temperature
+  Decimal('80.0')
+
 
 .. _model_configuration:
 

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -233,9 +233,13 @@ class Model(object):
 
     __optionsclass__ = ModelOptions
 
-    def __init__(self, raw_data=None, deserialize_mapping=None, strict=True):
+    def __init__(self, raw_data=None, deserialize_mapping=None, strict=True, **kwargs):
         if raw_data is None:
             raw_data = {}
+
+        if type(raw_data) is dict:
+            raw_data.update(kwargs)
+
         self._initial = raw_data
         self._data = self.convert(raw_data, strict=strict, mapping=deserialize_mapping)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,6 +18,19 @@ def test_init_with_dict():
     p1 = Player({"id": 4})
     assert p1.id == 4
 
+def test_init_with_kwargs():
+    class Player(Model):
+        id = IntType()
+
+    p1 = Player(id=4)
+    assert p1.id == 4
+
+def test_init_with_kwargs_overrides_dict():
+    class Player(Model):
+        id = IntType()
+
+    p1 = Player({'id': 2}, id=4)
+    assert p1.id == 4
 
 def test_invalid_model_fail_validation():
     class Player(Model):


### PR DESCRIPTION
Addresses #312 

I opted to override values provided in a raw_data dict for simplicity. We could do one of the following instead if preferred:

1. the inverse behavior
2. raise ConversionError if raw_data contains a key provided as a kwarg.