### PR TITLE
Fix NumberType range validation messages

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -447,8 +447,8 @@ class NumberType(BaseType):
 
     MESSAGES = {
         'number_coerce': u"Value '{0}' is not {1}",
-        'number_min': u"{0} value should be greater than {1}",
-        'number_max': u"{0} value should be less than {1}",
+        'number_min': u"{0} value should be greater than or equal to {1}",
+        'number_max': u"{0} value should be less than or equal to {1}",
     }
 
     def __init__(self, number_class, number_type,


### PR DESCRIPTION
For `min_value` and `max_value` the errors said 'greater than' and 'less than' but according to the code it should be 'greater than or equal to' and 'less than or equal to'.