### PR TITLE
Remove mock from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     },
     install_requires=[
         'six>=1.7.3',
-        'mock==1.0.1',
     ],
     tests_require=tests_require,
 )


### PR DESCRIPTION
`mock` is only being used in tests.