### PR TITLE
avoid unnecessary code path through try/except

### DIFF
--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -100,13 +100,15 @@ def import_loop(cls, instance_or_dict, field_converter, context=None,
             if raw_value is None:
                 if field.required and not partial:
                     errors[serialized_field_name] = [field.messages['required']]
-            else:
+            elif mapping:
                 try:
                     mapping_by_model = mapping.get('model_mapping', {})
                     model_mapping = mapping_by_model.get(field_name, {})
                     raw_value = field_converter(field, raw_value, mapping=model_mapping)
                 except Exception:
                     raw_value = field_converter(field, raw_value)
+            else:
+                raw_value = field_converter(field, raw_value)
 
             data[field_name] = raw_value
 


### PR DESCRIPTION
In one common use case (e.g. where import_loop is called from validate.py) there is no mapping passed into import_loop, and the field_converter function doesn't even take a mapping keyword argument.

Where there is no mapping, it's probably best to skip the try branch. It will only do two useless gets which inevitably end up with an empty dict. That {} is passed into a function that will at best do nothing with it or raise a TypeError through the except branch.

I suggest going straight to a mapping-less call to field_converter if no mapping was passed into import_loop to begin with.

All unit tests pass. I've informally profiled in PyCharm, and there is a slight improvement on our (Skyscanner's) test cases.