### PR TITLE
Change ListType validation messages to be a dict of index to message

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -189,12 +189,13 @@ class ListType(MultiType):
             raise ValidationError(message)
 
     def validate_items(self, items):
-        errors = []
-        for item in items:
+        errors = {}
+        for index, value in enumerate(items):
             try:
-                self.field.validate(item)
+                self.field.validate(value)
             except ValidationError as exc:
-                errors.append(exc.messages)
+                errors[index] = exc
+
         if errors:
             raise ValidationError(errors)
 

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -196,7 +196,7 @@ def test_list_model_field_exception_with_full_message():
 
     with pytest.raises(ValidationError) as exception:
         g.validate()
-    assert exception.value.messages == {'users': [{'name': ['String value is too long.']}]}
+    assert exception.value.messages == {'users': {0: {'name': ['String value is too long.']}}}
 
 
 def test_stop_validation():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -64,8 +64,9 @@ def test_validation_none_fails():
     with pytest.raises(ValidationError) as exception:
         Player({"first_name": None}).validate()
 
-        assert len(exception.messages) == 1  # Only one failure
-        assert u'This field is required' in exception.messages["first_name"][0]
+    messages = exception.value.messages
+    assert len(messages) == 1  # Only one failure
+    assert u'This field is required' in messages["first_name"][0]
 
 
 def test_custom_validators():
@@ -87,7 +88,8 @@ def test_custom_validators():
             "title": "Old Man"
         }).validate()
 
-        assert future_error_msg in exception.messages['publish']
+    messages = exception.value.messages
+    assert future_error_msg in messages['publish']
 
 
 def test_messages_subclassing():
@@ -100,7 +102,8 @@ def test_messages_subclassing():
     with pytest.raises(ValidationError) as exception:
         TestDoc({'title': None}).validate()
 
-        assert u'Never forget' in exception.messages['title']
+    messages = exception.value.messages
+    assert u'Never forget' in messages['title']
 
 
 def test_messages_instance_level():
@@ -109,7 +112,8 @@ def test_messages_instance_level():
 
     with pytest.raises(ValidationError) as exception:
         TestDoc({'title': None}).validate()
-        assert u'Never forget' in exception.messages['title']
+    messages = exception.value.messages
+    assert u'Never forget' in messages['title']
 
 
 def test_model_validators():
@@ -204,10 +208,10 @@ def test_basic_error():
     with pytest.raises(ValidationError) as exception:
         school.validate()
 
-        errors = exception.messages
+    errors = exception.value.messages
 
-        assert "name" in errors
-        assert errors["name"] == ["This field is required."]
+    assert "name" in errors
+    assert errors["name"] == ["This field is required."]
 
 
 def test_deep_errors():
@@ -225,11 +229,11 @@ def test_deep_errors():
     with pytest.raises(ValidationError) as exception:
         school.validate()
 
-        errors = exception.messages
+    errors = exception.value.messages
 
-        assert "headmaster" in errors
-        assert "name" in errors["headmaster"]
-        assert errors["headmaster"]["name"] == ["This field is required."]
+    assert "headmaster" in errors
+    assert "name" in errors["headmaster"]
+    assert errors["headmaster"]["name"] == ["This field is required."]
 
 
 def test_deep_errors_with_lists():
@@ -265,19 +269,19 @@ def test_deep_errors_with_lists():
     with pytest.raises(ValidationError) as exception:
         school.validate()
 
-        messages = exception.messages
+    messages = exception.value.messages
 
-        assert messages == {
-            'courses': [
-                {
-                    'attending': [
-                        {
-                            'name': [u'This field is required.'],
-                        },
-                    ],
-                }
-            ]
-        }
+    assert messages == {
+        'courses': [
+            {
+                'attending': [
+                    {
+                        'name': [u'This field is required.'],
+                    },
+                ],
+            }
+        ]
+    }
 
 
 def test_deep_errors_with_dicts():
@@ -318,20 +322,20 @@ def test_deep_errors_with_dicts():
     with pytest.raises(ValidationError) as exception:
         school.validate()
 
-        messages = exception.messages
+    messages = exception.value.messages
 
-        assert messages == {
-            'courses': {
-                "ENG103":
-                {
-                    'attending': [
-                        {
-                            'name': [u'This field is required.']
-                        }
-                    ]
-                }
+    assert messages == {
+        'courses': {
+            "ENG103":
+            {
+                'attending': [
+                    {
+                        'name': [u'This field is required.']
+                    }
+                ]
             }
         }
+    }
 
 
 def test_clean_validation_messages():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -272,15 +272,15 @@ def test_deep_errors_with_lists():
     messages = exception.value.messages
 
     assert messages == {
-        'courses': [
-            {
-                'attending': [
-                    {
-                        'name': [u'This field is required.'],
-                    },
-                ],
+        'courses': {
+            0: {
+                'attending': {
+                    0: {
+                        'name': ['This field is required.']
+                    }
+                }
             }
-        ]
+        }
     }
 
 
@@ -326,13 +326,12 @@ def test_deep_errors_with_dicts():
 
     assert messages == {
         'courses': {
-            "ENG103":
-            {
-                'attending': [
-                    {
-                        'name': [u'This field is required.']
+            'ENG103': {
+                'attending': {
+                    0: {
+                        'name': ['This field is required.']
                     }
-                ]
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, ListType validation error messages do not tell you WHICH item
in the list was invalid; just that one of them was. This is problematic
for showing validation errors in a UI; you typically want to show the
message next to a specific field.

I believe that a dict of item index to one or more errors (in a list) is
the most usable format for UI developers. I'm also open to returning a
list of dicts, where the position in the list matches the position in
the input; though that would often necessitate empty placeholders.

Addresses: https://github.com/schematics/schematics/issues/307

Also, fix assertions on a number of tests for validate messages:

These pytest.raises blocks stop executing when the ValidationError is
raised, meaning that any code underneath that in the block is not
executed. This included a few assertions on the actual validate
messages.