### PR TITLE
support arbitrary kwargs to a field

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -175,7 +175,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
 
     def __init__(self, required=False, default=None, serialized_name=None,
                  choices=None, validators=None, deserialize_from=None,
-                 serialize_when_none=None, messages=None):
+                 serialize_when_none=None, messages=None, **kwargs):
         super(BaseType, self).__init__()
         self.required = required
         self._default = default
@@ -184,6 +184,9 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
             raise TypeError('"choices" must be a list or tuple')
         self.choices = choices
         self.deserialize_from = deserialize_from
+
+        for key, val in kwargs:
+            setattr(self, key, val)
 
         self.validators = [functools.partial(v, self) for v in self._validators]
         if validators:

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -185,7 +185,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         self.choices = choices
         self.deserialize_from = deserialize_from
 
-        for key, val in kwargs:
+        for key, val in kwargs.items():
             setattr(self, key, val)
 
         self.validators = [functools.partial(v, self) for v in self._validators]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -293,3 +293,8 @@ def test_boolean_to_native():
     for bad_value in ['TrUe', 'foo', 2, None, 1.0]:
         with pytest.raises(ConversionError):
             bool_field.to_native(bad_value)
+
+def test_field_type_kwargs():
+    field = StringType(required=True, unique=True)
+
+    assert field.unique == True


### PR DESCRIPTION
This will allow us to document additional domain specific
attributes on the schema & potentially use them for certain
things.

An example would be a type attribute of `unique=True` where
all fields could be enumerated for unique attributes & auto
generate database constraints.