### PR TITLE
Add support for self-referential ModelType fields

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -199,6 +199,13 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
     def _mock(self, context=None):
         return None
 
+    def _setup(self, field_name, owner_model):
+        """Perform late-stage setup tasks that are run after the containing model 
+        has been created.
+        """
+        self.name = field_name
+        self.owner_model = owner_model
+
     @property
     def default(self):
         default = self._default

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -67,13 +67,17 @@ class ModelType(MultiType):
     def fields(self):
         return self.model_class.fields
 
-    def __init__(self, model_class, **kwargs):
+    def __init__(self, model_spec, **kwargs):
 
-        if not isinstance(model_class, (ModelMeta, basestring)):
-            raise TypeError("The first argument to ModelType.__init__() "
-                            "must be a model or the name of a model.")
-
-        self.model_class = model_class
+        if isinstance(model_spec, ModelMeta):
+            self.model_class = model_spec
+            self.model_name = self.model_class.__name__
+        elif isinstance(model_spec, basestring):
+            self.model_class = None
+            self.model_name = model_spec
+        else:
+            raise TypeError("ModelType: Expected a model, got an argument "
+                            "of the type '{}'.".format(model_spec.__class__.__name__))
 
         validators = kwargs.pop("validators", [])
         self.strict = kwargs.pop("strict", True)
@@ -89,11 +93,11 @@ class ModelType(MultiType):
 
     def _setup(self, field_name, owner_model):
         # Resolve possible name-based model reference.
-        if isinstance(self.model_class, basestring):
-            if self.model_class == owner_model.__name__:
+        if not self.model_class:
+            if self.model_name == owner_model.__name__:
                 self.model_class = owner_model
             else:
-                raise Exception("Unable to resolve model '{}'".format(self.model_class))
+                raise Exception("ModelType: Unable to resolve model '{}'.".format(self.model_name))
         super(ModelType, self)._setup(field_name, owner_model)
 
     def to_native(self, value, mapping=None, context=None):
@@ -315,14 +319,13 @@ class DictType(MultiType):
 
 class PolyModelType(MultiType):
 
-    def __init__(self, model_classes, **kwargs):
+    def __init__(self, model_spec, **kwargs):
 
-        if isinstance(model_classes, type) and issubclass(model_classes, Model):
-            self.model_classes = (model_classes,)
+        if isinstance(model_spec, (ModelMeta, basestring)):
+            self.model_classes = (model_spec,)
             allow_subclasses = True
-        elif isinstance(model_classes, Iterable) \
-          and not isinstance(model_classes, basestring):
-            self.model_classes = tuple(model_classes)
+        elif isinstance(model_spec, Iterable):
+            self.model_classes = tuple(model_spec)
             allow_subclasses = False
         else:
             raise Exception("The first argument to PolyModelType.__init__() "
@@ -341,6 +344,20 @@ class PolyModelType(MultiType):
 
     def __repr__(self):
         return object.__repr__(self)[:-1] + ' for %s>' % str(self.model_classes)
+
+    def _setup(self, field_name, owner_model):
+        # Resolve possible name-based model references.
+        resolved_classes = []
+        for m in self.model_classes:
+            if isinstance(m, basestring):
+                if m == owner_model.__name__:
+                    resolved_classes.append(owner_model)
+                else:
+                    raise Exception("PolyModelType: Unable to resolve model '{}'.".format(m))
+            else:
+                resolved_classes.append(m)
+        self.model_classes = tuple(resolved_classes)
+        super(PolyModelType, self)._setup(field_name, owner_model)
 
     def is_allowed_model(self, model_instance):
         if self.allow_subclasses:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -57,9 +57,17 @@ class MultiType(BaseType):
 
 class ModelType(MultiType):
 
+    @property
+    def fields(self):
+        return self.model_class.fields
+
     def __init__(self, model_class, **kwargs):
+
+        if not isinstance(model_class, (ModelMeta, basestring)):
+            raise TypeError("The first argument to ModelType.__init__() "
+                            "must be a model or the name of a model.")
+
         self.model_class = model_class
-        self.fields = self.model_class.fields
 
         validators = kwargs.pop("validators", [])
         self.strict = kwargs.pop("strict", True)
@@ -401,4 +409,4 @@ class PolyModelType(MultiType):
             return shaped
 
 
-from ..models import Model
+from ..models import Model, ModelMeta

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -168,3 +168,17 @@ def test_export_loop_with_subclassed_model():
 
     native = product.to_native()
     assert 'bucket_name' in native['asset']
+
+
+def test_reference_model_by_name():
+
+    class M(Model):
+        to_one = ModelType('M')
+        to_many = ListType(ModelType('M'))
+        matrix = ListType(ListType(ModelType('M')))
+
+    assert M.to_one.model_class is M
+    assert M.to_many.field.model_class is M
+    assert M.matrix.field.field.model_class is M
+
+

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -170,7 +170,7 @@ def test_export_loop_with_subclassed_model():
     assert 'bucket_name' in native['asset']
 
 
-def test_reference_model_by_name():
+def test_specify_model_by_name():
 
     class M(Model):
         to_one = ModelType('M')

--- a/tests/test_polymodeltype.py
+++ b/tests/test_polymodeltype.py
@@ -2,7 +2,7 @@ import pytest
 
 from schematics.models import Model
 from schematics.types import StringType
-from schematics.types.compound import PolyModelType
+from schematics.types.compound import PolyModelType, ListType
 
 
 class A(Model): # fallback model (doesn't define a claim method)
@@ -115,4 +115,16 @@ def test_refuse_unrelated_export():
         foo = Foo()
         foo.strict = Aaa()
         foo.to_primitive()
+
+
+def test_specify_model_by_name():
+
+    class M(Model):
+        single = PolyModelType('M')
+        multi = PolyModelType([A, 'M', C])
+        nested = ListType(ListType(PolyModelType('M')))
+
+    assert M.single.is_allowed_model(M())
+    assert M.multi.is_allowed_model(M())
+    assert M.nested.field.field.is_allowed_model(M())
 


### PR DESCRIPTION
Implements the feature requested in #330.

Commit message:

ModelType fields can now be initialized with a string consisting of the name of the containing model. These will be turned into actual class references once the class has been created.
