### PR TITLE
Don't evaluate serializable when accessed through class

### DIFF
--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -54,7 +54,10 @@ class Serializable(object):
             self.export_loop = make_export_loop(self.type)
 
     def __get__(self, instance, cls):
-        return self.func(instance)
+        if instance:
+            return self.func(instance)
+        else:
+            return self
 
     def to_native(self, value, context=None):
         return self.type.to_native(value, context)


### PR DESCRIPTION
Consider:

```python
class M(Model):

    f = StringType()

    @serializable
    def s(self):
        return 'foo'
```

Since `M.f == M._fields['f']`, I would expect `M.s == M._serializables['s']` to be true as well.

But accessing `M.s` currently results in `M.s()` to be evaluated as if it were a classmethod. I suspect this is not by design. Does anyone else see a reason why this should be so?
