### PR TITLE
Support Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ install:
   - pip install tox
   - pip install python-coveralls
 
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5
+
 script: tox
 
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     cmdclass={
         'test': Tox,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 indexserver =
     pypi = https://pypi.python.org/simple
 


### PR DESCRIPTION
- Add py35 to list of tox environments
- Add Python 3.5 to language classifiers
- Upgrade pytest version to address issues with Python 3.5
  (https://github.com/pytest-dev/pytest/pull/801)