### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-pytest==2.5.1
+pytest>=2.5.1
 coverage
 python-coveralls
-python-dateutil==2.2
-pymongo==2.7.1
-ordereddict==1.1
-tox==1.9
-mock==1.0.1
-Sphinx==1.1.3
+python-dateutil>=2.2
+pymongo>=2.7.1
+tox>=1.9
+mock>=1.0.1
+Sphinx>=1.1.3

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -1,8 +1,4 @@
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict  # python2.6 fallback
-
+from schematics.datastructures import OrderedDict
 from schematics.transforms import expand, whitelist, flatten
 from schematics.models import Model
 from schematics.types.serializable import serializable


### PR DESCRIPTION
* Eliminate the last remaining reference to the external `ordereddict` library and remove it from the dependency list.

* Specify dependencies as `>= <version>` instead of requiring exact, potentially outdated releases.
