### PR TITLE
Fix FieldDescriptor.__delete__ to not touch model

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -71,12 +71,12 @@ class FieldDescriptor(object):
 
     def __delete__(self, instance):
         """
-        Checks the field name against a model and deletes the field.
+        Checks the field name against a model and deletes the value.
         """
-        if self.name not in instance._fields:
-            raise AttributeError('%r has no attribute %r' %
-                                 (type(instance).__name__, self.name))
-        del instance._fields[self.name]
+        try:
+            instance._data[self.name] = None
+        except KeyError:
+            raise AttributeError(self.name)
 
 
 class ModelOptions(object):
@@ -382,8 +382,7 @@ class Model(object):
         try:
             return getattr(self, name)
         except AttributeError:
-            pass
-        raise KeyError(name)
+            raise KeyError(name)
 
     def __setitem__(self, name, value):
         if name not in self._data:
@@ -391,9 +390,10 @@ class Model(object):
         return setattr(self, name, value)
 
     def __delitem__(self, name):
-        if name not in self._data:
+        try:
+            return delattr(self, name)
+        except AttributeError:
             raise KeyError(name)
-        return setattr(self, name, None)
 
     def __contains__(self, name):
         return name in self._data or name in self._serializables

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -486,13 +486,6 @@ def test_fielddescriptor_connectedness():
     with pytest.raises(AttributeError):
         inst.field1
 
-    inst = TestModel()
-    del inst._fields['field1']
-    with pytest.raises(AttributeError):
-        del inst.field1
-
-    del inst.field2
-
 
 def test_keys():
     class TestModel(Model):


### PR DESCRIPTION
Currently, `del model_instance.somefield` performs

```python
del model_instance._fields['somefield']
```

But instances don't have a `_fields` member, so this results in `somefield` to be dropped not from the instance but **from the class, affecting all instances**.

This patch changes the behavior of `FieldDescriptor.__delete__` to match that of `Model.__delitem__`, which simply resets the field's value to `None`.

If manipulating `_fields` is necessary, it should be done through the class.
