### PR TITLE
export_loop cleanup

### DIFF
--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -178,26 +178,23 @@ def export_loop(cls, instance_or_dict, field_converter,
                 shaped = field_converter(field, value)
 
             # Print if we want none or found a value
-            if shaped is None and allow_none(cls, field):
-                data[serialized_name] = shaped
-            elif shaped is not None:
-                data[serialized_name] = shaped
-            elif print_none:
+            if shaped is not None \
+              or allow_none(cls, field) \
+              or print_none:
                 data[serialized_name] = shaped
 
         # Store None if reqeusted
-        elif value is None and allow_none(cls, field):
-            data[serialized_name] = value
-        elif print_none:
+        elif allow_none(cls, field) or print_none:
             data[serialized_name] = value
 
+    if fields_order:
+        data = sort_dict(data, fields_order)
+
     # Return data if the list contains anything
-    if len(data) > 0:
-        if fields_order:
-            return sort_dict(data, fields_order)
+    if len(data) > 0 or print_none:
         return data
-    elif print_none:
-        return data
+    else:
+        return None
 
 
 def sort_dict(dct, based_on):

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -110,12 +110,10 @@ class ModelType(MultiType):
                              field_converter,
                              role=role, print_none=print_none)
 
-        if shaped and len(shaped) == 0 and self.allow_none():
+        if shaped or print_none:
             return shaped
-        elif shaped:
-            return shaped
-        elif print_none:
-            return shaped
+        else:
+            return None
 
 
 class ListType(MultiType):
@@ -196,26 +194,23 @@ class ListType(MultiType):
             if hasattr(self.field, 'export_loop'):
                 shaped = self.field.export_loop(value, field_converter,
                                                 role=role)
-                feels_empty = shaped and len(shaped) == 0
+                feels_empty = shaped is None or len(shaped) == 0
             else:
                 shaped = field_converter(self.field, value)
                 feels_empty = shaped is None
 
             # Print if we want empty or found a value
-            if feels_empty and self.field.allow_none():
-                data.append(shaped)
-            elif shaped is not None:
-                data.append(shaped)
-            elif print_none:
+            if feels_empty:
+                if self.field.allow_none():
+                    data.append(shaped)
+            elif shaped is not None or print_none:
                 data.append(shaped)
 
         # Return data if the list contains anything
-        if len(data) > 0:
+        if len(data) > 0 or self.allow_none() or print_none:
             return data
-        elif len(data) == 0 and self.allow_none():
-            return data
-        elif print_none:
-            return data
+        else:
+            return None
 
 
 class DictType(MultiType):
@@ -271,24 +266,21 @@ class DictType(MultiType):
             if hasattr(self.field, 'export_loop'):
                 shaped = self.field.export_loop(value, field_converter,
                                                 role=role)
-                feels_empty = shaped and len(shaped) == 0
+                feels_empty = shaped is None or len(shaped) == 0
             else:
                 shaped = field_converter(self.field, value)
                 feels_empty = shaped is None
 
-            if feels_empty and self.field.allow_none():
-                data[key] = shaped
-            elif shaped is not None:
-                data[key] = shaped
-            elif print_none:
+            if feels_empty:
+                if self.field.allow_none():
+                    data[key] = shaped
+            elif shaped is not None or print_none:
                 data[key] = shaped
 
-        if len(data) > 0:
+        if len(data) > 0 or self.allow_none() or print_none:
             return data
-        elif len(data) == 0 and self.allow_none():
-            return data
-        elif print_none:
-            return data
+        else:
+            return None
 
 
 class PolyModelType(MultiType):
@@ -394,10 +386,8 @@ class PolyModelType(MultiType):
                              field_converter,
                              role=role, print_none=print_none)
 
-        if shaped and len(shaped) == 0 and self.allow_none():
+        if shaped or print_none:
             return shaped
-        elif shaped:
-            return shaped
-        elif print_none:
-            return shaped
+        else:
+            return None
 


### PR DESCRIPTION
In `export_loop` functions,
* get rid of redundancies in conditionals
* when about to return `None`, do so explicitly.

Can someone with more historical knowledge please check if any of the removed code in `compound.py` was intended to do something but didn't because it was buggy?

Specifically:

1. In `ModelType.export_loop()` we had

  ```python
  if shaped and len(shaped) == 0 and self.allow_none():
      return shaped
  elif shaped:
      return shaped
  elif print_none:
      return shaped
  ```

  All cases covered by the first conditional are covered by the second as well. But maybe the second one was supposed to read something like:

  ```python
  elif shaped and len(shaped) > 0:
      return shaped
  ```

  But still, this would only make sense for a custom representation that's not a `dict`, yet the main `export_loop` function only returns dictionaries.

2. The `feels_empty` variable in `ListType/DictType.export_loop()` didn't serve any purpose, which I found strange.
