### PR TITLE
Always export empty compound objects as {} / []

### DIFF
--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -190,11 +190,7 @@ def export_loop(cls, instance_or_dict, field_converter,
     if fields_order:
         data = sort_dict(data, fields_order)
 
-    # Return data if the list contains anything
-    if len(data) > 0 or print_none:
-        return data
-    else:
-        return None
+    return data
 
 
 def sort_dict(dct, based_on):

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -178,26 +178,23 @@ def export_loop(cls, instance_or_dict, field_converter,
                 shaped = field_converter(field, value)
 
             # Print if we want none or found a value
-            if shaped is None and allow_none(cls, field):
-                data[serialized_name] = shaped
-            elif shaped is not None:
-                data[serialized_name] = shaped
-            elif print_none:
+            if shaped is not None \
+              or allow_none(cls, field) \
+              or print_none:
                 data[serialized_name] = shaped
 
         # Store None if reqeusted
-        elif value is None and allow_none(cls, field):
-            data[serialized_name] = value
-        elif print_none:
+        elif allow_none(cls, field) or print_none:
             data[serialized_name] = value
 
+    if fields_order:
+        data = sort_dict(data, fields_order)
+
     # Return data if the list contains anything
-    if len(data) > 0:
-        if fields_order:
-            return sort_dict(data, fields_order)
+    if len(data) > 0 or print_none:
         return data
-    elif print_none:
-        return data
+    else:
+        return None
 
 
 def sort_dict(dct, based_on):

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -174,13 +174,16 @@ def export_loop(cls, instance_or_dict, field_converter,
                 shaped = field.export_loop(value, field_converter,
                                            role=role,
                                            print_none=print_none)
+                feels_empty = shaped is None or len(shaped) == 0
             else:
                 shaped = field_converter(field, value)
+                feels_empty = shaped is None
 
             # Print if we want none or found a value
-            if shaped is not None \
-              or allow_none(cls, field) \
-              or print_none:
+            if feels_empty:
+                if allow_none(cls, field) or print_none:
+                    data[serialized_name] = shaped
+            elif shaped is not None:
                 data[serialized_name] = shaped
 
         # Store None if reqeusted

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -203,11 +203,7 @@ class ListType(MultiType):
             elif shaped is not None or print_none:
                 data.append(shaped)
 
-        # Return data if the list contains anything
-        if len(data) > 0 or self.allow_none() or print_none:
-            return data
-        else:
-            return None
+        return data
 
 
 class DictType(MultiType):
@@ -274,10 +270,7 @@ class DictType(MultiType):
             elif shaped is not None or print_none:
                 data[key] = shaped
 
-        if len(data) > 0 or self.allow_none() or print_none:
-            return data
-        else:
-            return None
+        return data
 
 
 class PolyModelType(MultiType):
@@ -383,8 +376,5 @@ class PolyModelType(MultiType):
                              field_converter,
                              role=role, print_none=print_none)
 
-        if shaped or print_none:
-            return shaped
-        else:
-            return None
+        return shaped
 

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -198,9 +198,9 @@ class ListType(MultiType):
 
             # Print if we want empty or found a value
             if feels_empty:
-                if self.field.allow_none():
+                if self.field.allow_none() or print_none:
                     data.append(shaped)
-            elif shaped is not None or print_none:
+            elif shaped is not None:
                 data.append(shaped)
 
         return data
@@ -265,9 +265,9 @@ class DictType(MultiType):
                 feels_empty = shaped is None
 
             if feels_empty:
-                if self.field.allow_none():
+                if self.field.allow_none() or print_none:
                     data[key] = shaped
-            elif shaped is not None or print_none:
+            elif shaped is not None:
                 data[key] = shaped
 
         return data

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -110,10 +110,7 @@ class ModelType(MultiType):
                              field_converter,
                              role=role, print_none=print_none)
 
-        if shaped or print_none:
-            return shaped
-        else:
-            return None
+        return shaped
 
 
 class ListType(MultiType):

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -110,12 +110,10 @@ class ModelType(MultiType):
                              field_converter,
                              role=role, print_none=print_none)
 
-        if shaped and len(shaped) == 0 and self.allow_none():
+        if shaped or print_none:
             return shaped
-        elif shaped:
-            return shaped
-        elif print_none:
-            return shaped
+        else:
+            return None
 
 
 class ListType(MultiType):
@@ -196,26 +194,23 @@ class ListType(MultiType):
             if hasattr(self.field, 'export_loop'):
                 shaped = self.field.export_loop(value, field_converter,
                                                 role=role)
-                feels_empty = shaped and len(shaped) == 0
+                feels_empty = shaped is None or len(shaped) == 0
             else:
                 shaped = field_converter(self.field, value)
                 feels_empty = shaped is None
 
             # Print if we want empty or found a value
-            if feels_empty and self.field.allow_none():
-                data.append(shaped)
-            elif shaped is not None:
-                data.append(shaped)
-            elif print_none:
+            if feels_empty:
+                if self.field.allow_none():
+                    data.append(shaped)
+            elif shaped is not None or print_none:
                 data.append(shaped)
 
         # Return data if the list contains anything
-        if len(data) > 0:
+        if len(data) > 0 or self.allow_none() or print_none:
             return data
-        elif len(data) == 0 and self.allow_none():
-            return data
-        elif print_none:
-            return data
+        else:
+            return None
 
 
 class DictType(MultiType):
@@ -271,24 +266,21 @@ class DictType(MultiType):
             if hasattr(self.field, 'export_loop'):
                 shaped = self.field.export_loop(value, field_converter,
                                                 role=role)
-                feels_empty = shaped and len(shaped) == 0
+                feels_empty = shaped is None or len(shaped) == 0
             else:
                 shaped = field_converter(self.field, value)
                 feels_empty = shaped is None
 
-            if feels_empty and self.field.allow_none():
-                data[key] = shaped
-            elif shaped is not None:
-                data[key] = shaped
-            elif print_none:
+            if feels_empty:
+                if self.field.allow_none():
+                    data[key] = shaped
+            elif shaped is not None or print_none:
                 data[key] = shaped
 
-        if len(data) > 0:
+        if len(data) > 0 or self.allow_none() or print_none:
             return data
-        elif len(data) == 0 and self.allow_none():
-            return data
-        elif print_none:
-            return data
+        else:
+            return None
 
 
 class PolyModelType(MultiType):
@@ -394,10 +386,8 @@ class PolyModelType(MultiType):
                              field_converter,
                              role=role, print_none=print_none)
 
-        if shaped and len(shaped) == 0 and self.allow_none():
+        if shaped or print_none:
             return shaped
-        elif shaped:
-            return shaped
-        elif print_none:
-            return shaped
+        else:
+            return None
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -823,7 +823,7 @@ def test_role_set_operations():
 
     d = user.serialize(role='empty')
 
-    assert d is None
+    assert d == {}
 
     d = user.serialize(role='everything')
 


### PR DESCRIPTION
This PR changes the primitive representation of empty models from `None` to `{}` (empty `dict`) so as to make a distinction between an actual `None` and an instance that has no values to export.

It depends on #350, which fixes the filtering of empty containers during export, and addresses  #235.

Diff for the relevant commit: https://github.com/schematics/schematics/commit/912afcc02c5506290d8fe5d818207c141cc6d1e3

#### Motivation

The current behavior can lead to counterintuitive outcomes, particularly when using the `serialize_when_none` switch.

Example:

```python
class Inner(Model):
    class Options:
        serialize_when_none = False
    l = ListType(IntType())

class Outer(Model):
    m = ModelType(Inner)
```

```python
>>> instance = Outer()
>>> instance.to_primitive()
{'m': None} # as expected since instance.m hasn't been set
```

```python
>>> instance.m = Inner({'l': [123]})
>>> instance.to_primitive()
{'m': {'l': [123]}} # again as expected
```

Let's mutate the list:

```python
>>> instance.m.l.pop()
>>> instance.to_primitive()
{'m': None} # !!!
```

The `Inner` object still very much exists at `instance.m` but is reduced to `None` because it has nothing to export.

The patch changes the output in this case to `{'m': {}}`.
