### PR TITLE
Support returning a sanitized value from validators

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -236,7 +236,9 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
 
         for validator in self.validators:
             try:
-                validator(value)
+                clean_value = validator(value)
+                if getattr(validator, 'returns', False) is True:
+                    value = clean_value
             except ValidationError as exc:
                 errors.extend(exc.messages)
 
@@ -245,6 +247,8 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
 
         if errors:
             raise ValidationError(errors)
+
+        return value
 
     def validate_required(self, value):
         if self.required and value is None:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -25,7 +25,9 @@ class MultiType(BaseType):
 
         for validator in self.validators:
             try:
-                validator(value)
+                clean_value = validator(value)
+                if getattr(validator, 'returns', False) is True:
+                    value = clean_value
             except ModelValidationError as exc:
                 errors.update(exc.messages)
             except StopValidation as exc:


### PR DESCRIPTION
The docs imply that validators may return a modified value to replace the original, but this is not true (#206). This PR adds support for return values from both type-level and model-level validators.

Since most validators today likely return an implicit `None`, a validator that is *really* going to return a modified value must be specially designated as such. This is done by decorating the validator with `@returns` (defined in `validate.py`).

Custom types that override `BaseType.validate()` and fail to return a value will stop working (fields will be set to `None` upon validation). But overriding `validate()` is probably rare, and the docstring clearly says to "return a clean value".
