### PR TITLE
Propagate environment during recursive import/export/validation

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -228,14 +228,14 @@ class Model(object):
     __optionsclass__ = ModelOptions
 
     def __init__(self, raw_data=None, deserialize_mapping=None,
-                 partial=True, strict=True, app_data=None, env=None):
+                 partial=True, strict=True, app_data=None, context=None):
         if raw_data is None:
             raw_data = {}
         self._initial = raw_data
         self._data = self.convert(raw_data, strict=strict, partial=partial,
-                                  mapping=deserialize_mapping, app_data=app_data, env=env)
+                                  mapping=deserialize_mapping, app_data=app_data, context=context)
 
-    def validate(self, partial=False, strict=False, app_data=None, env=None):
+    def validate(self, partial=False, strict=False, app_data=None, context=None):
         """
         Validates the state of the model and adding additional untrusted data
         as well. If the models is invalid, raises ValidationError with error
@@ -250,7 +250,7 @@ class Model(object):
         """
         try:
             data = validate(self.__class__, self._data, partial=partial,
-                            strict=strict, app_data=app_data, env=env)
+                            strict=strict, app_data=app_data, context=context)
             self._data.update(**data)
         except BaseError as exc:
             raise ModelValidationError(exc.messages)
@@ -282,10 +282,10 @@ class Model(object):
         """
         return convert(self.__class__, raw_data, **kw)
 
-    def to_native(self, role=None, app_data=None, env=None):
-        return to_native(self.__class__, self, role=role, app_data=app_data, env=env)
+    def to_native(self, role=None, app_data=None, context=None):
+        return to_native(self.__class__, self, role=role, app_data=app_data, context=context)
 
-    def to_primitive(self, role=None, app_data=None, env=None):
+    def to_primitive(self, role=None, app_data=None, context=None):
         """Return data as it would be validated. No filtering of output unless
         role is defined.
 
@@ -293,12 +293,12 @@ class Model(object):
             Filter output by a specific role
 
         """
-        return to_primitive(self.__class__, self, role=role, app_data=app_data, env=env)
+        return to_primitive(self.__class__, self, role=role, app_data=app_data, context=context)
 
-    def serialize(self, role=None, app_data=None, env=None):
-        return self.to_primitive(role=role, app_data=app_data, env=env)
+    def serialize(self, role=None, app_data=None, context=None):
+        return self.to_primitive(role=role, app_data=app_data, context=context)
 
-    def flatten(self, role=None, prefix="", app_data=None, env=None):
+    def flatten(self, role=None, prefix="", app_data=None, context=None):
         """
         Return data as a pure key-value dictionary, where the values are
         primitive types (string, bool, int, long).
@@ -309,7 +309,7 @@ class Model(object):
             A prefix to use for keynames during flattening.
         """
         return flatten(self.__class__, self, role=role, prefix=prefix,
-                       app_data=app_data, env=env)
+                       app_data=app_data, context=context)
 
     @classmethod
     def from_flat(cls, data):
@@ -355,10 +355,10 @@ class Model(object):
             return default
 
     @classmethod
-    def get_mock_object(cls, env=None, overrides=None):
+    def get_mock_object(cls, context=None, overrides=None):
         """Get a mock object.
 
-        :param dict env:
+        :param dict context:
         :param dict overrides: overrides for the model
         """
         if overrides is None:
@@ -367,7 +367,7 @@ class Model(object):
         for name, field in cls.fields.items():
             if name not in overrides:
                 try:
-                    values[name] = field.mock(env)
+                    values[name] = field.mock(context)
                 except MockCreationError as exc:
                     raise MockCreationError('%s: %s' % (name, exc.message))
         values.update(overrides)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -282,10 +282,10 @@ class Model(object):
         """
         return convert(self.__class__, raw_data, **kw)
 
-    def to_native(self, role=None, context=None):
-        return to_native(self.__class__, self, role=role, context=context)
+    def to_native(self, role=None, env=None):
+        return to_native(self.__class__, self, role=role, env=env)
 
-    def to_primitive(self, role=None, context=None):
+    def to_primitive(self, role=None, env=None):
         """Return data as it would be validated. No filtering of output unless
         role is defined.
 
@@ -293,10 +293,10 @@ class Model(object):
             Filter output by a specific role
 
         """
-        return to_primitive(self.__class__, self, role=role, context=context)
+        return to_primitive(self.__class__, self, role=role, env=env)
 
-    def serialize(self, role=None, context=None):
-        return self.to_primitive(role=role, context=context)
+    def serialize(self, role=None, env=None):
+        return self.to_primitive(role=role, env=env)
 
     def flatten(self, role=None, prefix=""):
         """
@@ -354,10 +354,10 @@ class Model(object):
             return default
 
     @classmethod
-    def get_mock_object(cls, context=None, overrides=None):
+    def get_mock_object(cls, env=None, overrides=None):
         """Get a mock object.
 
-        :param dict context:
+        :param dict env:
         :param dict overrides: overrides for the model
         """
         if overrides is None:
@@ -366,7 +366,7 @@ class Model(object):
         for name, field in cls.fields.items():
             if name not in overrides:
                 try:
-                    values[name] = field.mock(context)
+                    values[name] = field.mock(env)
                 except MockCreationError as exc:
                     raise MockCreationError('%s: %s' % (name, exc.message))
         values.update(overrides)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -228,14 +228,14 @@ class Model(object):
     __optionsclass__ = ModelOptions
 
     def __init__(self, raw_data=None, deserialize_mapping=None,
-                 partial=True, strict=True, env=None):
+                 partial=True, strict=True, app_data=None, env=None):
         if raw_data is None:
             raw_data = {}
         self._initial = raw_data
         self._data = self.convert(raw_data, strict=strict, partial=partial,
-                                  mapping=deserialize_mapping, env=env)
+                                  mapping=deserialize_mapping, app_data=app_data, env=env)
 
-    def validate(self, partial=False, strict=False, env=None):
+    def validate(self, partial=False, strict=False, app_data=None, env=None):
         """
         Validates the state of the model and adding additional untrusted data
         as well. If the models is invalid, raises ValidationError with error
@@ -250,7 +250,7 @@ class Model(object):
         """
         try:
             data = validate(self.__class__, self._data, partial=partial,
-                            strict=strict, env=env)
+                            strict=strict, app_data=app_data, env=env)
             self._data.update(**data)
         except BaseError as exc:
             raise ModelValidationError(exc.messages)
@@ -282,10 +282,10 @@ class Model(object):
         """
         return convert(self.__class__, raw_data, **kw)
 
-    def to_native(self, role=None, env=None):
-        return to_native(self.__class__, self, role=role, env=env)
+    def to_native(self, role=None, app_data=None, env=None):
+        return to_native(self.__class__, self, role=role, app_data=app_data, env=env)
 
-    def to_primitive(self, role=None, env=None):
+    def to_primitive(self, role=None, app_data=None, env=None):
         """Return data as it would be validated. No filtering of output unless
         role is defined.
 
@@ -293,12 +293,12 @@ class Model(object):
             Filter output by a specific role
 
         """
-        return to_primitive(self.__class__, self, role=role, env=env)
+        return to_primitive(self.__class__, self, role=role, app_data=app_data, env=env)
 
-    def serialize(self, role=None, env=None):
-        return self.to_primitive(role=role, env=env)
+    def serialize(self, role=None, app_data=None, env=None):
+        return self.to_primitive(role=role, app_data=app_data, env=env)
 
-    def flatten(self, role=None, prefix=""):
+    def flatten(self, role=None, prefix="", app_data=None, env=None):
         """
         Return data as a pure key-value dictionary, where the values are
         primitive types (string, bool, int, long).
@@ -308,7 +308,8 @@ class Model(object):
         :param prefix:
             A prefix to use for keynames during flattening.
         """
-        return flatten(self.__class__, self, role=role, prefix=prefix)
+        return flatten(self.__class__, self, role=role, prefix=prefix,
+                       app_data=app_data, env=env)
 
     @classmethod
     def from_flat(cls, data):

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -179,7 +179,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
     def __call__(self, value):
         return self.to_native(value)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return None
 
     def _setup(self, field_name, owner_model):
@@ -196,12 +196,12 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
             default = self._default()
         return default
 
-    def to_primitive(self, value, env=None):
+    def to_primitive(self, value, context=None):
         """Convert internal data to a value safe to serialize.
         """
         return value
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         """
         Convert untrusted data to a richer Python construct.
         """
@@ -213,7 +213,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         else:
             return self.serialize_when_none
 
-    def validate(self, value, env=None):
+    def validate(self, value, context=None):
         """
         Validate the field and return a clean value or raise a
         ``ValidationError`` with a list of errors raised by the validation
@@ -235,18 +235,18 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         if errors:
             raise ValidationError(errors)
 
-    def validate_choices(self, value, env=None):
+    def validate_choices(self, value, context=None):
         if self.choices is not None:
             if value not in self.choices:
                 raise ValidationError(self.messages['choices']
                                       .format(unicode(self.choices)))
 
-    def mock(self, env=None):
+    def mock(self, context=None):
         if not self.required and not random.choice([True, False]):
             return self.default
         if self.choices is not None:
             return random.choice(self.choices)
-        return self._mock(env)
+        return self._mock(context)
 
 
 class UUIDType(BaseType):
@@ -257,10 +257,10 @@ class UUIDType(BaseType):
         'convert': u"Couldn't interpret '{0}' value as UUID.",
     }
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return uuid.uuid4()
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         if not isinstance(value, uuid.UUID):
             try:
                 value = uuid.UUID(value)
@@ -268,7 +268,7 @@ class UUIDType(BaseType):
                 raise ConversionError(self.messages['convert'].format(value))
         return value
 
-    def to_primitive(self, value, env=None):
+    def to_primitive(self, value, context=None):
         return str(value)
 
 
@@ -276,7 +276,7 @@ class IPv4Type(BaseType):
 
     """ A field that stores a valid IPv4 address """
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return '.'.join(str(random.randrange(256)) for _ in range(4))
 
     @classmethod
@@ -323,10 +323,10 @@ class StringType(BaseType):
 
         super(StringType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return random_string(get_value_in(self.min_length, self.max_length))
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         if value is None:
             return None
 
@@ -381,7 +381,7 @@ class URLType(StringType):
         self.verify_exists = verify_exists
         super(URLType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return fill_template('http://a%s.ZZ', self.min_length,
                              self.max_length)
 
@@ -417,7 +417,7 @@ class EmailType(StringType):
         re.IGNORECASE
     )
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return fill_template('%s@example.com', self.min_length,
                              self.max_length)
 
@@ -446,10 +446,10 @@ class NumberType(BaseType):
 
         super(NumberType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return get_value_in(self.min_value, self.max_value)
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         try:
             value = self.number_class(value)
         except (TypeError, ValueError):
@@ -533,13 +533,13 @@ class DecimalType(BaseType):
 
         super(DecimalType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return get_value_in(self.min_value, self.max_value)
 
-    def to_primitive(self, value, env=None):
+    def to_primitive(self, value, context=None):
         return unicode(value)
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         if not isinstance(value, decimal.Decimal):
             if not isinstance(value, basestring):
                 value = unicode(value)
@@ -569,10 +569,10 @@ class HashType(BaseType):
         'hash_hex': u"Hash value is not hexadecimal.",
     }
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return random_string(self.LENGTH, string.hexdigits)
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         if len(value) != self.LENGTH:
             raise ValidationError(self.messages['hash_length'])
         try:
@@ -611,10 +611,10 @@ class BooleanType(BaseType):
     TRUE_VALUES = ('True', 'true', '1')
     FALSE_VALUES = ('False', 'false', '0')
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return random.choice([True, False])
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         if isinstance(value, basestring):
             if value in self.TRUE_VALUES:
                 value = True
@@ -644,14 +644,14 @@ class DateType(BaseType):
         self.serialized_format = self.SERIALIZED_FORMAT
         super(DateType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return datetime.datetime(
             year=random.randrange(600) + 1900,
             month=random.randrange(12) + 1,
             day=random.randrange(28) + 1,
         )
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         if isinstance(value, datetime.date):
             return value
 
@@ -660,7 +660,7 @@ class DateType(BaseType):
         except (ValueError, TypeError):
             raise ConversionError(self.messages['parse'].format(value))
 
-    def to_primitive(self, value, env=None):
+    def to_primitive(self, value, context=None):
         return value.strftime(self.serialized_format)
 
 
@@ -771,7 +771,7 @@ class DateTimeType(BaseType):
 
         super(DateTimeType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return datetime.datetime(
             year=random.randrange(600) + 1900,
             month=random.randrange(12) + 1,
@@ -782,7 +782,7 @@ class DateTimeType(BaseType):
             microsecond=random.randrange(1000000),
         )
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
 
         if isinstance(value, datetime.datetime):
             if value.tzinfo is None:
@@ -873,7 +873,7 @@ class DateTimeType(BaseType):
         except (ValueError, TypeError):
             return None
 
-    def to_primitive(self, value, env=None):
+    def to_primitive(self, value, context=None):
         if callable(self.serialized_format):
             return self.serialized_format(value)
         return value.strftime(self.serialized_format)
@@ -928,10 +928,10 @@ class GeoPointType(BaseType):
         'point_max': u"{0} value {1} should be less than {2}."
     }
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return (random.randrange(-90, 90), random.randrange(-180, 180))
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         """Make sure that a geo-value is of type (x, y)
         """
         if not len(value) == 2:
@@ -978,7 +978,7 @@ class MultilingualStringType(BaseType):
 
     Minimum and maximum lengths apply to each of the localized values.
 
-    At least one of ``default_locale`` or ``env.app_data['locale']`` must be defined
+    At least one of ``default_locale`` or ``context.app_data['locale']`` must be defined
     when calling ``.to_primitive``.
 
     """
@@ -1007,10 +1007,10 @@ class MultilingualStringType(BaseType):
 
         super(MultilingualStringType, self).__init__(**kwargs)
 
-    def _mock(self, env=None):
+    def _mock(self, context=None):
         return random_string(get_value_in(self.min_length, self.max_length))
 
-    def to_native(self, value, env=None):
+    def to_native(self, value, context=None):
         """Make sure a MultilingualStringType value is a dict or None."""
 
         if not (value is None or isinstance(value, dict)):
@@ -1018,9 +1018,9 @@ class MultilingualStringType(BaseType):
 
         return value
 
-    def to_primitive(self, value, env=None):
+    def to_primitive(self, value, context=None):
         """
-        Use a combination of ``default_locale`` and ``env.app_data['locale']`` to return
+        Use a combination of ``default_locale`` and ``context.app_data['locale']`` to return
         the best localized string.
 
         """
@@ -1028,8 +1028,8 @@ class MultilingualStringType(BaseType):
             return None
 
         context_locale = None
-        if env and 'locale' in env.app_data:
-            context_locale = env.app_data['locale']
+        if context and 'locale' in context.app_data:
+            context_locale = context.app_data['locale']
 
         # Build a list of all possible locales to try
         possible_locales = []

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -978,7 +978,7 @@ class MultilingualStringType(BaseType):
 
     Minimum and maximum lengths apply to each of the localized values.
 
-    At least one of ``default_locale`` or ``env.context['locale']`` must be defined
+    At least one of ``default_locale`` or ``env.app_data['locale']`` must be defined
     when calling ``.to_primitive``.
 
     """
@@ -1020,7 +1020,7 @@ class MultilingualStringType(BaseType):
 
     def to_primitive(self, value, env=None):
         """
-        Use a combination of ``default_locale`` and ``env.context['locale']`` to return
+        Use a combination of ``default_locale`` and ``env.app_data['locale']`` to return
         the best localized string.
 
         """
@@ -1028,8 +1028,8 @@ class MultilingualStringType(BaseType):
             return None
 
         context_locale = None
-        if env and env.context is not None and 'locale' in env.context:
-            context_locale = env.context['locale']
+        if env and 'locale' in env.app_data:
+            context_locale = env.app_data['locale']
 
         # Build a list of all possible locales to try
         possible_locales = []

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -172,6 +172,10 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         self.messages = dict(self.MESSAGES, **(messages or {}))
         self._position_hint = next(_next_position_hint)  # For ordering of fields
 
+        self.name = None
+        self.owner_model = None
+        self.parent_field = None
+
     def __call__(self, value):
         return self.to_native(value)
 
@@ -204,7 +208,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         return value
 
     def allow_none(self):
-        if hasattr(self, 'owner_model'):
+        if self.owner_model:
             return self.owner_model.allow_none(self)
         else:
             return self.serialize_when_none
@@ -230,10 +234,6 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
 
         if errors:
             raise ValidationError(errors)
-
-    def validate_required(self, value, env=None):
-        if self.required and value is None and not (env and env.partial):
-            raise ValidationError(self.messages['required'])
 
     def validate_choices(self, value, env=None):
         if self.choices is not None:

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -209,7 +209,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         else:
             return self.serialize_when_none
 
-    def validate(self, value):
+    def validate(self, value, env=None):
         """
         Validate the field and return a clean value or raise a
         ``ValidationError`` with a list of errors raised by the validation
@@ -225,24 +225,23 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
                 validator(value)
             except ValidationError as exc:
                 errors.extend(exc.messages)
-
                 if isinstance(exc, StopValidation):
                     break
 
         if errors:
             raise ValidationError(errors)
 
-    def validate_required(self, value):
-        if self.required and value is None:
+    def validate_required(self, value, env=None):
+        if self.required and value is None and not (env and env.partial):
             raise ValidationError(self.messages['required'])
 
-    def validate_choices(self, value):
+    def validate_choices(self, value, env=None):
         if self.choices is not None:
             if value not in self.choices:
                 raise ValidationError(self.messages['choices']
                                       .format(unicode(self.choices)))
 
-    def mock(self, context=None):
+    def mock(self, context=None, env=None):
         if not self.required and not random.choice([True, False]):
             return self.default
         if self.choices is not None:

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -59,8 +59,8 @@ class Serializable(object):
         else:
             return self
 
-    def to_native(self, value, context=None):
-        return self.type.to_native(value, context)
+    def to_native(self, value, env=None):
+        return self.type.to_native(value, env)
 
-    def to_primitive(self, value, context=None):
-        return self.type.to_primitive(value, context)
+    def to_primitive(self, value, env=None):
+        return self.type.to_primitive(value, env)

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -59,8 +59,8 @@ class Serializable(object):
         else:
             return self
 
-    def to_native(self, value, env=None):
-        return self.type.to_native(value, env)
+    def to_native(self, value, context=None):
+        return self.type.to_native(value, context)
 
-    def to_primitive(self, value, env=None):
-        return self.type.to_primitive(value, env)
+    def to_primitive(self, value, context=None):
+        return self.type.to_primitive(value, context)

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -1,8 +1,7 @@
 from .exceptions import BaseError, ValidationError, ModelConversionError
-from .transforms import import_loop
 
 
-def validate(cls, instance_or_dict, partial=False, strict=False, context=None):
+def validate(cls, instance_or_dict, partial=False, strict=False, context=None, env=None):
     """
     Validate some untrusted data using a model. Trusted data can be passed in
     the `context` parameter.
@@ -30,15 +29,19 @@ def validate(cls, instance_or_dict, partial=False, strict=False, context=None):
     errors = {}
 
     # Function for validating an individual field
-    def field_converter(field, value):
-        value = field.to_native(value)
-        field.validate(value)
+    def field_converter(field, value, env=None):
+        if isinstance(field, MultiType):
+            value = field.to_native(value, env=env)
+            field.validate(value, env=env)
+        else:
+            value = field.to_native(value)
+            field.validate(value)
         return value
 
     # Loop across fields and coerce values
     try:
         data = import_loop(cls, instance_or_dict, field_converter,
-                           context=context, partial=partial, strict=strict)
+                           context=context, partial=partial, strict=strict, env=env)
     except ModelConversionError as mce:
         errors = mce.messages
 
@@ -110,3 +113,7 @@ def _check_for_unknown_fields(cls, data):
         for field_name in rogues_found:
             errors[field_name] = [u'%s is an illegal field.' % field_name]
     return errors
+
+
+from .types.compound import MultiType
+from .transforms import import_loop

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -1,7 +1,8 @@
 from .exceptions import BaseError, ValidationError, ModelConversionError
 
 
-def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=None, env=None):
+def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=None,
+             app_data=None, env=None):
     """
     Validate some untrusted data using a model. Trusted data can be passed in
     the `trusted_data` parameter.
@@ -37,7 +38,8 @@ def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=No
     # Loop across fields and coerce values
     try:
         data = import_loop(cls, instance_or_dict, field_converter,
-                           trusted_data=trusted_data, partial=partial, strict=strict, env=env)
+                           trusted_data=trusted_data, partial=partial, strict=strict,
+                           app_data=app_data, env=env)
     except ModelConversionError as mce:
         errors = mce.messages
 

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -5,4 +5,4 @@ from schematics.types.compound import MultiType
 
 def test_base_does_not_implement_export_loop():
     with pytest.raises(NotImplementedError):
-        MultiType().export_loop(None, None)
+        MultiType().export_loop(None, None, None)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -66,7 +66,7 @@ def test_validate_with_instance_level_validators():
     class Player(Model):
         id = IntType()
 
-        def validate_id(self, context, value):
+        def validate_id(self, context, value, env):
             if p1._initial['id'] != value:
                 p1._data['id'] = p1._initial['id']
                 raise ValidationError('Cannot change id')

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -11,53 +11,53 @@ def test_validate_simple_dict():
     validate(Player, {'id': 4})
 
 
-def test_validate_keep_context_data():
+def test_validate_keep_trusted_data():
     class Player(Model):
         id = IntType()
         name = StringType()
 
     p1 = Player({'id': 4})
-    data = validate(Player, {'name': 'Arthur'}, context=p1._data)
+    data = validate(Player, {'name': 'Arthur'}, trusted_data=p1._data)
 
     assert data == {'id': 4, 'name': 'Arthur'}
     assert data != p1._data
 
 
-def test_validate_override_context_data():
+def test_validate_override_trusted_data():
     class Player(Model):
         id = IntType()
 
     p1 = Player({'id': 4})
-    data = validate(Player, {'id': 3}, context=p1._data)
+    data = validate(Player, {'id': 3}, trusted_data=p1._data)
 
     assert data == {'id': 3}
 
 
-def test_validate_ignore_extra_context_data():
+def test_validate_ignore_extra_trusted_data():
     class Player(Model):
         id = IntType()
 
-    data = validate(Player, {'id': 4}, context={'name': 'Arthur'})
+    data = validate(Player, {'id': 4}, trusted_data={'name': 'Arthur'})
 
     assert data == {'id': 4, 'name': 'Arthur'}
 
 
-def test_validate_strict_with_context_data():
+def test_validate_strict_with_trusted_data():
     class Player(Model):
         id = IntType()
 
     try:
-        validate(Player, {'id': 4}, strict=True, context={'name': 'Arthur'})
+        validate(Player, {'id': 4}, strict=True, trusted_data={'name': 'Arthur'})
     except ValidationError as e:
         assert 'name' in e.messages
 
 
-def test_validate_partial_with_context_data():
+def test_validate_partial_with_trusted_data():
     class Player(Model):
         id = IntType()
         name = StringType(required=True)
 
-    data = validate(Player, {'id': 4}, partial=False, context={'name': 'Arthur'})
+    data = validate(Player, {'id': 4}, partial=False, trusted_data={'name': 'Arthur'})
 
     assert data == {'id': 4, 'name': 'Arthur'}
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -66,7 +66,7 @@ def test_validate_with_instance_level_validators():
     class Player(Model):
         id = IntType()
 
-        def validate_id(self, context, value, env):
+        def validate_id(self, data, value, context):
             if p1._initial['id'] != value:
                 p1._data['id'] = p1._initial['id']
                 raise ValidationError('Cannot change id')

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -201,7 +201,7 @@ def test_list_model_field_exception_with_full_message():
 
 
 def test_stop_validation():
-    def raiser(x):
+    def raiser(*args, **kwargs):
         raise StopValidation({'something': 'bad'})
 
     lst = ListType(StringType(), validators=[raiser])

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -151,6 +151,9 @@ def test_list_field_required():
         "ids": []
     })
 
+    c.ids = []
+    c.validate()
+
     c.ids = [1]
     c.validate()
 

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -1,5 +1,6 @@
 import pytest
 
+from schematics.datastructures import ConfigObject
 from schematics.models import Model
 from schematics.types import IntType, StringType
 from schematics.types.compound import ModelType, ListType
@@ -28,7 +29,7 @@ def test_simple_embedded_models():
     assert isinstance(p.location, Location)
     assert p.location.country_code == "IS"
 
-    assert Player.location.to_native(None) is None
+    assert Player.location.to_native(None, ConfigObject()) is None
 
 
 def test_simple_embedded_models_is_none():

--- a/tests/test_polymodeltype.py
+++ b/tests/test_polymodeltype.py
@@ -39,7 +39,7 @@ class Foo(Model):
     base   = PolyModelType(A)       # accepts any subclass for import and export
     strict = PolyModelType([A, B])  # accepts [A, B] for import and export
     nfb    = PolyModelType([B, C])  # no fallback since A not present
-    cfn    = PolyModelType([B, C], claim_function=claim_func, strict=False)
+    cfn    = PolyModelType([B, C], claim_function=claim_func)
 
 
 def test_subclass_registry():
@@ -83,7 +83,7 @@ def test_enumerated_polymorphic(): # strict
 
 def test_external_claim_function(): # cfn
 
-    foo = Foo({'cfn': {'stringB': 'bbb', 'stringC': 'ccc'}})
+    foo = Foo({'cfn': {'stringB': 'bbb', 'stringC': 'ccc'}}, strict=False)
     assert type(foo.cfn) is B
 
 def test_multiple_matches():

--- a/tests/test_recursive_import.py
+++ b/tests/test_recursive_import.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from schematics.models import Model
+from schematics.types import BaseType, IntType, StringType
+from schematics.types.compound import ListType, DictType, ModelType
+from schematics.exceptions import ModelConversionError, ModelValidationError
+
+def test_nested_mapping():
+
+    mapping = {
+        'model_mapping': {
+            'modelfield': {
+                'subfield': 'importfield'
+            }
+        }
+    }
+
+    class SubModel(Model):
+        subfield = StringType()
+
+    class MainModel(Model):
+        modelfield = ModelType(SubModel)
+
+    m1 = MainModel({
+        'modelfield': {'importfield':'qweasd'},
+        }, deserialize_mapping=mapping)
+
+    assert m1.modelfield.subfield == 'qweasd'
+
+def test_nested_mapping_with_required():
+
+    mapping = {
+        'model_mapping': {
+            'modelfield': {
+                'subfield': 'importfield'
+            }
+        }
+    }
+
+    class SubModel(Model):
+        subfield = StringType(required=True)
+
+    class MainModel(Model):
+        modelfield = ModelType(SubModel)
+
+    m1 = MainModel({ # Note partial=False here!
+        'modelfield': {'importfield':'qweasd'},
+        }, partial=False, deserialize_mapping=mapping)
+
+def test_submodel_required_field():
+
+    class SubModel(Model):
+        subfield1 = StringType(required=True)
+        subfield2 = StringType()
+
+    class MainModel(Model):
+        intfield = IntType()
+        stringfield = StringType()
+        modelfield = ModelType(SubModel)
+
+    # By default, model instantiation assumes partial=True
+    m1 = MainModel({
+        'modelfield': {'subfield2':'qweasd'}})
+
+    with pytest.raises(ModelConversionError):
+        m1 = MainModel({
+            'modelfield': {'subfield2':'qweasd'}}, partial=False)
+
+    # Validation implies partial=False
+    with pytest.raises(ModelValidationError):
+        m1.validate()
+
+    m1.validate(partial=True)
+

--- a/tests/test_recursive_import.py
+++ b/tests/test_recursive_import.py
@@ -28,6 +28,7 @@ def test_nested_mapping():
 
     assert m1.modelfield.subfield == 'qweasd'
 
+
 def test_nested_mapping_with_required():
 
     mapping = {
@@ -44,9 +45,10 @@ def test_nested_mapping_with_required():
     class MainModel(Model):
         modelfield = ModelType(SubModel)
 
-    m1 = MainModel({ # Note partial=False here!
+    m1 = MainModel({
         'modelfield': {'importfield':'qweasd'},
         }, partial=False, deserialize_mapping=mapping)
+
 
 def test_submodel_required_field():
 
@@ -72,4 +74,24 @@ def test_submodel_required_field():
         m1.validate()
 
     m1.validate(partial=True)
+
+
+def test_strict_propagation():
+
+    class SubModel(Model):
+        subfield = StringType()
+
+    class MainModel(Model):
+        modelfield = ModelType(SubModel)
+
+    with pytest.raises(ModelConversionError):
+        m1 = MainModel({
+            'modelfield': {'extrafield':'qweasd'},
+            }, strict=True)
+
+    m1 = MainModel({
+        'modelfield': {'extrafield':'qweasd'},
+        }, strict=False)
+
+    assert m1.modelfield._data == {'subfield': None}
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -475,7 +475,7 @@ def test_serialize_none_fields_if_field_says_so():
 
     q = TestModel({'inst_id': 1})
 
-    d = export_loop(TestModel, q, lambda field, value, env: None)
+    d = export_loop(TestModel, q, lambda field, value, context: None)
     assert d == {'inst_id': None}
 
 
@@ -485,7 +485,7 @@ def test_serialize_none_fields_if_export_loop_says_so():
 
     q = TestModel({'inst_id': 1})
 
-    d = export_loop(TestModel, q, lambda field, value, env: None, print_none=True)
+    d = export_loop(TestModel, q, lambda field, value, context: None, print_none=True)
     assert d == {'inst_id': None}
 
 
@@ -495,7 +495,7 @@ def test_serialize_print_none_always_gets_you_something():
 
     q = TestModel()
 
-    d = export_loop(TestModel, q, lambda field, value, env: None, print_none=True)
+    d = export_loop(TestModel, q, lambda field, value, context: None, print_none=True)
     assert d == {}
 
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -475,7 +475,7 @@ def test_serialize_none_fields_if_field_says_so():
 
     q = TestModel({'inst_id': 1})
 
-    d = export_loop(TestModel, q, lambda field, value: None)
+    d = export_loop(TestModel, q, lambda field, value, env: None)
     assert d == {'inst_id': None}
 
 
@@ -485,7 +485,7 @@ def test_serialize_none_fields_if_export_loop_says_so():
 
     q = TestModel({'inst_id': 1})
 
-    d = export_loop(TestModel, q, lambda field, value: None, print_none=True)
+    d = export_loop(TestModel, q, lambda field, value, env: None, print_none=True)
     assert d == {'inst_id': None}
 
 
@@ -495,7 +495,7 @@ def test_serialize_print_none_always_gets_you_something():
 
     q = TestModel()
 
-    d = export_loop(TestModel, q, lambda field, value: None, print_none=True)
+    d = export_loop(TestModel, q, lambda field, value, env: None, print_none=True)
     assert d == {}
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,6 +8,7 @@ import uuid
 
 import pytest
 
+from schematics.models import Model
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
     URLType, MultilingualStringType, UUIDType, IPv4Type, MD5Type, BooleanType,
@@ -147,19 +148,22 @@ def test_url_type_with_unreachable_url():
 
 
 def test_string_type_required():
-    field = StringType(required=True)
+    class M(Model):
+        field = StringType(required=True)
     with pytest.raises(ValidationError):
-        field.validate(None)
+        M({'field': None}).validate()
 
 
 def test_string_type_accepts_none():
-    field = StringType()
-    field.validate(None)
+    class M(Model):
+        field = StringType()
+    M({'field': None}).validate()
 
 
 def test_string_required_accepts_empty_string():
-    field = StringType(required=True)
-    field.validate('')
+    class M(Model):
+        field = StringType()
+    M({'field': ''}).validate()
 
 
 def test_string_min_length_doesnt_accept_empty_string():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,7 +8,7 @@ import uuid
 
 import pytest
 
-from schematics.datastructures import ConfigObject
+from schematics.transforms import ExportContext
 from schematics.models import Model
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
@@ -267,7 +267,7 @@ def test_multilingual_string_should_emit_string_with_explicit_locale():
 
     assert mls.to_primitive(
         {'en_US': 'snake', 'fr_FR': 'serpent'},
-        env=ConfigObject({'context': {'locale': 'fr_FR'}})) == 'serpent'
+        env=ExportContext(app_data={'locale': 'fr_FR'})) == 'serpent'
 
 
 def test_multilingual_string_should_require_a_locale():
@@ -284,7 +284,7 @@ def test_multilingual_string_without_matching_locale_should_explode():
         mls.to_primitive({'fr_FR': 'serpent'})
 
     with pytest.raises(ConversionError):
-        mls.to_primitive({'en_US': 'snake'}, env=ConfigObject({'context': {'locale': 'fr_FR'}}))
+        mls.to_primitive({'en_US': 'snake'}, env=ExportContext(app_data={'locale': 'fr_FR'}))
 
 
 def test_multilingual_string_should_accept_lists_of_locales():
@@ -297,11 +297,11 @@ def test_multilingual_string_should_accept_lists_of_locales():
     mls = MultilingualStringType(default_locale=['foo', 'fr_FR', 'es_MX'])
 
     assert mls.to_primitive(strings) == 'serpent'
-    assert mls.to_primitive(strings, env=ConfigObject({'context': {'locale': ['es_MX', 'bar']}})) == 'serpiente'
+    assert mls.to_primitive(strings, env=ExportContext(app_data={'locale': ['es_MX', 'bar']})) == 'serpiente'
 
     mls = MultilingualStringType()
 
-    assert mls.to_primitive(strings, env=ConfigObject({'context': {'locale': ['foo', 'es_MX', 'fr_FR']}})) == 'serpiente'
+    assert mls.to_primitive(strings, env=ExportContext(app_data={'locale': ['foo', 'es_MX', 'fr_FR']})) == 'serpiente'
 
 
 def test_boolean_to_native():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -8,6 +8,7 @@ import uuid
 
 import pytest
 
+from schematics.datastructures import ConfigObject
 from schematics.models import Model
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
@@ -266,7 +267,7 @@ def test_multilingual_string_should_emit_string_with_explicit_locale():
 
     assert mls.to_primitive(
         {'en_US': 'snake', 'fr_FR': 'serpent'},
-        context={'locale': 'fr_FR'}) == 'serpent'
+        env=ConfigObject({'context': {'locale': 'fr_FR'}})) == 'serpent'
 
 
 def test_multilingual_string_should_require_a_locale():
@@ -283,7 +284,7 @@ def test_multilingual_string_without_matching_locale_should_explode():
         mls.to_primitive({'fr_FR': 'serpent'})
 
     with pytest.raises(ConversionError):
-        mls.to_primitive({'en_US': 'snake'}, context={'locale': 'fr_FR'})
+        mls.to_primitive({'en_US': 'snake'}, env=ConfigObject({'context': {'locale': 'fr_FR'}}))
 
 
 def test_multilingual_string_should_accept_lists_of_locales():
@@ -296,11 +297,11 @@ def test_multilingual_string_should_accept_lists_of_locales():
     mls = MultilingualStringType(default_locale=['foo', 'fr_FR', 'es_MX'])
 
     assert mls.to_primitive(strings) == 'serpent'
-    assert mls.to_primitive(strings, context={'locale': ['es_MX', 'bar']}) == 'serpiente'
+    assert mls.to_primitive(strings, env=ConfigObject({'context': {'locale': ['es_MX', 'bar']}})) == 'serpiente'
 
     mls = MultilingualStringType()
 
-    assert mls.to_primitive(strings, context={'locale': ['foo', 'es_MX', 'fr_FR']}) == 'serpiente'
+    assert mls.to_primitive(strings, env=ConfigObject({'context': {'locale': ['foo', 'es_MX', 'fr_FR']}})) == 'serpiente'
 
 
 def test_boolean_to_native():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -267,7 +267,7 @@ def test_multilingual_string_should_emit_string_with_explicit_locale():
 
     assert mls.to_primitive(
         {'en_US': 'snake', 'fr_FR': 'serpent'},
-        env=ExportContext(app_data={'locale': 'fr_FR'})) == 'serpent'
+        context=ExportContext(app_data={'locale': 'fr_FR'})) == 'serpent'
 
 
 def test_multilingual_string_should_require_a_locale():
@@ -284,7 +284,7 @@ def test_multilingual_string_without_matching_locale_should_explode():
         mls.to_primitive({'fr_FR': 'serpent'})
 
     with pytest.raises(ConversionError):
-        mls.to_primitive({'en_US': 'snake'}, env=ExportContext(app_data={'locale': 'fr_FR'}))
+        mls.to_primitive({'en_US': 'snake'}, context=ExportContext(app_data={'locale': 'fr_FR'}))
 
 
 def test_multilingual_string_should_accept_lists_of_locales():
@@ -297,11 +297,11 @@ def test_multilingual_string_should_accept_lists_of_locales():
     mls = MultilingualStringType(default_locale=['foo', 'fr_FR', 'es_MX'])
 
     assert mls.to_primitive(strings) == 'serpent'
-    assert mls.to_primitive(strings, env=ExportContext(app_data={'locale': ['es_MX', 'bar']})) == 'serpiente'
+    assert mls.to_primitive(strings, context=ExportContext(app_data={'locale': ['es_MX', 'bar']})) == 'serpiente'
 
     mls = MultilingualStringType()
 
-    assert mls.to_primitive(strings, env=ExportContext(app_data={'locale': ['foo', 'es_MX', 'fr_FR']})) == 'serpiente'
+    assert mls.to_primitive(strings, context=ExportContext(app_data={'locale': ['foo', 'es_MX', 'fr_FR']})) == 'serpiente'
 
 
 def test_boolean_to_native():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -122,7 +122,7 @@ def test_model_validators():
         can_future = BooleanType()
         publish = DateTimeType()
 
-        def validate_publish(self, data, dt):
+        def validate_publish(self, data, dt, env):
             if dt > datetime.datetime(2012, 1, 1, 0, 0) and not data['can_future']:
                 raise ValidationError(future_error_msg)
 
@@ -140,7 +140,7 @@ def test_multi_key_validation():
         should_raise = BooleanType(default=True)
         publish = DateTimeType()
 
-        def validate_publish(self, data, dt):
+        def validate_publish(self, data, dt, env):
             if data['should_raise'] is True:
                 raise ValidationError(u'')
             return dt
@@ -159,7 +159,7 @@ def test_multi_key_validation_part_two():
         name = StringType()
         call_me = BooleanType(default=False)
 
-        def validate_call_me(self, data, value):
+        def validate_call_me(self, data, value, env):
             if data['name'] == u'Brad' and value is True:
                 raise ValidationError(u'I\'m sorry I never call people who\'s name is Brad')
             return value
@@ -176,14 +176,14 @@ def test_multi_key_validation_fields_order():
         name = StringType()
         call_me = BooleanType(default=False)
 
-        def validate_name(self, data, value):
+        def validate_name(self, data, value, env):
             if data['name'] == u'Brad':
                 value = u'Joe'
                 data['name'] = value
                 return value
             return value
 
-        def validate_call_me(self, data, value):
+        def validate_call_me(self, data, value, env):
             if data['name'] == u'Joe':
                 raise ValidationError(u"Don't try to decept me! You're Joe!")
             return value

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -122,7 +122,7 @@ def test_model_validators():
         can_future = BooleanType()
         publish = DateTimeType()
 
-        def validate_publish(self, data, dt, env):
+        def validate_publish(self, data, dt, context):
             if dt > datetime.datetime(2012, 1, 1, 0, 0) and not data['can_future']:
                 raise ValidationError(future_error_msg)
 
@@ -140,7 +140,7 @@ def test_multi_key_validation():
         should_raise = BooleanType(default=True)
         publish = DateTimeType()
 
-        def validate_publish(self, data, dt, env):
+        def validate_publish(self, data, dt, context):
             if data['should_raise'] is True:
                 raise ValidationError(u'')
             return dt
@@ -159,7 +159,7 @@ def test_multi_key_validation_part_two():
         name = StringType()
         call_me = BooleanType(default=False)
 
-        def validate_call_me(self, data, value, env):
+        def validate_call_me(self, data, value, context):
             if data['name'] == u'Brad' and value is True:
                 raise ValidationError(u'I\'m sorry I never call people who\'s name is Brad')
             return value
@@ -176,14 +176,14 @@ def test_multi_key_validation_fields_order():
         name = StringType()
         call_me = BooleanType(default=False)
 
-        def validate_name(self, data, value, env):
+        def validate_name(self, data, value, context):
             if data['name'] == u'Brad':
                 value = u'Joe'
                 data['name'] = value
                 return value
             return value
 
-        def validate_call_me(self, data, value, env):
+        def validate_call_me(self, data, value, context):
             if data['name'] == u'Joe':
                 raise ValidationError(u"Don't try to decept me! You're Joe!")
             return value


### PR DESCRIPTION
A rewrite of #266.

This is a huge PR, but it's split into meaningful commits, each of which represents a working state with all tests passing.

`env` is now always passed to all `to_primitive`, `to_native`, and `export_loop` methods on types. Consequently, the standard `field_converter` interface also has `env` as a mandatory component: `field_converter(field, value, env)`.

The `env` object will be set up by either `import_loop` or `export_loop` during the first iteration if the application hasn't supplied it by then.


### `context`

The overloading of "context" with a number of uses has been resolved as follows:

  * `context` in `import_loop()` and `validate()` renamed to `trusted_data`
  * `context` as an argument to `to_native()`, `to_primitive()`, `validate()`, and `mock()` superseded by `env`
  * `context` as an argument to `expand` in `transforms.py` renamed to `expanded_data`
  * `context` when accessing the private context replaced by `env.context`.

Basically, `env.context` is just a recommendation for establishing a private namespace. Apparently the only thing in the library that accesses `env.context` is `MultiLingualString` that looks for a locale there.


### `export_loop` inspection gone

[DELETED]

### Miscellaneous changes

  * `ModelType.strict` option removed for now. To support something like this, we would need to differentiate between at least two flavors of settings:
    * static settings (specified as function defaults, model options, or `ModelType` definitions), where later (as in deeper level of recursion) overrides earlier
    * explicit settings (specified by application at runtime) that would override everything else.

  I suspect `ModelType.strict` may have been a band-aid to provide some degree of control where the runtime `strict` setting hasn't been doing anything.
  * `BaseType.validate_required()` removed. `import_loop` enforces `required=True` for fields directly on a model, so this was only needed for nested fields. They now get this validator in `MultiType.__init__()` as needed.


### Validators

`env` is now passed to all validators, including model-level validators. Although the object is absolutely needed only in compound type validators, it's probably best to make the change everywhere at once, since appending `env` to the argument list is all that is needed to adapt existing code.

