### PR TITLE
Collect field validators as bound methods

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -104,23 +104,23 @@ class TypeMeta(type):
 
     def __new__(mcs, name, bases, attrs):
         messages = {}
-        validators = []
+        validators = set()
 
         for base in reversed(bases):
             if hasattr(base, 'MESSAGES'):
                 messages.update(base.MESSAGES)
 
             if hasattr(base, "_validators"):
-                validators.extend(base._validators)
+                validators.update(base._validators)
 
         if 'MESSAGES' in attrs:
             messages.update(attrs['MESSAGES'])
 
         attrs['MESSAGES'] = messages
 
-        for attr_name, attr in iteritems(attrs):
+        for attr_name in attrs:
             if attr_name.startswith("validate_"):
-                validators.append(attr)
+                validators.add(attr_name)
 
         attrs["_validators"] = validators
 
@@ -185,7 +185,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         self.choices = choices
         self.deserialize_from = deserialize_from
 
-        self.validators = [functools.partial(v, self) for v in self._validators]
+        self.validators = [getattr(self, validator_name) for validator_name in self._validators]
         if validators:
             self.validators += validators
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,7 +6,7 @@ from schematics.exceptions import (
     BaseError, ValidationError, ConversionError,
     ModelValidationError, ModelConversionError,
 )
-from schematics.types import StringType, DateTimeType, BooleanType
+from schematics.types import StringType, DateTimeType, BooleanType, IntType
 from schematics.types.compound import ModelType, ListType, DictType
 
 
@@ -332,6 +332,31 @@ def test_deep_errors_with_dicts():
                 }
             }
         }
+
+
+def test_field_validator_override():
+
+    class CustomIntType(IntType):
+        def validate_range(self, value):
+            pass
+
+    CustomIntType(max_value=1).validate(9)
+
+
+def test_model_validator_override():
+
+    class Base(Model):
+        def validate_foo(self, data, value):
+            pass
+        def validate_bar(self, data, value):
+            pass
+
+    class Child(Base):
+        def validate_bar(self, data, value):
+            pass
+
+    assert Child._validator_functions['foo'] is Base._validator_functions['foo']
+    assert Child._validator_functions['bar'] is not Base._validator_functions['bar']
 
 
 def test_clean_validation_messages():


### PR DESCRIPTION
This makes fields pickleable. In addition, it allows validator methods
to override similarly named validators on parent types (previously they
would all run).

### Example

```python
class FooType(IntType):
    def validate_range(self, value):
        pass
```
```python
>>> field = FooType(max_value=1)
```

**Before:**

```python
>>> field.validators
[functools.partial(<function BaseType.validate_required at 0x1019d7400> ...),
 functools.partial(<function BaseType.validate_choices at 0x1019d7488> ...),
 functools.partial(<function NumberType.validate_is_a_number at 0x1019da0d0> ...),
 functools.partial(<function NumberType.validate_range at 0x1019da158> ...),
 functools.partial(<function FooType.validate_range at 0x101bc3a60> ...)]
```
```python
>>> field.validate(9)
Traceback (most recent call last):
  ...
  ...
schematics.exceptions.ValidationError: ['Int value should be less than 1.']
```
```python
>>> pickle.dumps(field)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
_pickle.PicklingError: Can't pickle <function BaseType.validate_required at 0x1019d7400>:
 attribute lookup validate_required on schematics.types.base failed
```

**After:**

```python
>>> field.validators
[<bound method FooType.validate_is_a_number of <__main__.FooType object at ...>>,
 <bound method FooType.validate_choices of <__main__.FooType object at ...>>,
 <bound method FooType.validate_required of <__main__.FooType object at ...>>,
 <bound method FooType.validate_range of <__main__.FooType object at ...>>]
```
```python
>>> field.validate(9)
```
```python
>>> pickle.dumps(field)
b'\x80\x03c__main__\nFooType\nq\x00...
```
