### PR TITLE
Make sure field.validate() uses a native type

### DIFF
--- a/schematics/contrib/mongo.py
+++ b/schematics/contrib/mongo.py
@@ -41,10 +41,3 @@ class ObjectIdType(BaseType):
     def to_primitive(self, value, context=None):
         return str(value)
 
-    def validate_id(self, value):
-        if not isinstance(value, bson.objectid.ObjectId):
-            try:
-                value = bson.objectid.ObjectId(unicode(value))
-            except Exception:
-                raise ValidationError('Invalid ObjectId')
-        return True

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -235,7 +235,7 @@ class Model(object):
         self._data = self.convert(raw_data, strict=strict, partial=partial,
                                   mapping=deserialize_mapping, app_data=app_data, context=context)
 
-    def validate(self, partial=False, strict=False, app_data=None, context=None):
+    def validate(self, partial=False, strict=False, convert=True, app_data=None, context=None):
         """
         Validates the state of the model and adding additional untrusted data
         as well. If the models is invalid, raises ValidationError with error
@@ -247,10 +247,15 @@ class Model(object):
             definitions. Default: False
         :param strict:
             Complain about unrecognized keys. Default: False
+        :param convert:
+            Controls whether to perform import conversion before validating.
+            Can be turned off to skip an unnecessary conversion step if all values
+            are known to have the right datatypes (e.g., when validating immediately
+            after the initial import). Default: True
         """
         try:
-            data = validate(self.__class__, self._data, partial=partial,
-                            strict=strict, app_data=app_data, context=context)
+            data = validate(self.__class__, self._data, partial=partial, strict=strict,
+                            convert=convert, app_data=app_data, context=context)
             self._data.update(**data)
         except BaseError as exc:
             raise ModelValidationError(exc.messages)

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -213,7 +213,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         else:
             return self.serialize_when_none
 
-    def validate(self, value, context=None):
+    def validate(self, value, convert=True, context=None):
         """
         Validate the field and return a clean value or raise a
         ``ValidationError`` with a list of errors raised by the validation
@@ -221,7 +221,8 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         validators by raising ``StopValidation`` instead of ``ValidationError``.
 
         """
-        value = self.to_native(value)
+        if convert:
+            value = self.to_native(value)
 
         errors = []
 

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -221,6 +221,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         validators by raising ``StopValidation`` instead of ``ValidationError``.
 
         """
+        value = self.to_native(value)
 
         errors = []
 
@@ -234,6 +235,8 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
 
         if errors:
             raise ValidationError(errors)
+
+        return value
 
     def validate_choices(self, value, context=None):
         if self.choices is not None:
@@ -457,13 +460,6 @@ class NumberType(BaseType):
                                   .format(value, self.number_type.lower()))
 
         return value
-
-    def validate_is_a_number(self, value):
-        try:
-            self.number_class(value)
-        except (TypeError, ValueError):
-            raise ConversionError(self.messages['number_coerce']
-                                  .format(value, self.number_type.lower()))
 
     def validate_range(self, value):
         if self.min_value is not None and value < self.min_value:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -36,12 +36,13 @@ class MultiType(BaseType):
             self.field._setup(None, owner_model)
         super(MultiType, self)._setup(field_name, owner_model)
 
-    def validate(self, value, context=None):
+    def validate(self, value, convert=True, context=None):
         """Report dictionary of errors with lists of errors as values of each
         key. Used by ModelType and ListType.
 
         """
-        value = self.to_native(value, context)
+        if convert:
+            value = self.to_native(value, context)
 
         errors = {}
 

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -41,6 +41,8 @@ class MultiType(BaseType):
         key. Used by ModelType and ListType.
 
         """
+        value = self.to_native(value, context)
+
         errors = {}
 
         for validator in self.validators:

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -31,9 +31,7 @@ def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=No
 
     # Function for validating an individual field
     def field_converter(field, value, context):
-        value = field.to_native(value, context)
-        field.validate(value, context)
-        return value
+        return field.validate(value, context)
 
     # Loop across fields and coerce values
     try:

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -2,7 +2,7 @@ from .exceptions import BaseError, ValidationError, ModelConversionError
 
 
 def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=None,
-             app_data=None, context=None):
+             convert=True, app_data=None, context=None):
     """
     Validate some untrusted data using a model. Trusted data can be passed in
     the `trusted_data` parameter.
@@ -20,6 +20,11 @@ def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=No
         Complain about unrecognized keys. Default: False
     :param trusted_data:
         A ``dict``-like structure that may contain already validated data.
+    :param convert:
+        Controls whether to perform import conversion before validating.
+        Can be turned off to skip an unnecessary conversion step if all values
+        are known to have the right datatypes (e.g., when validating immediately
+        after the initial import). Default: True
 
     :returns: data
         ``dict`` containing the valid raw_data plus ``trusted_data``.
@@ -31,7 +36,7 @@ def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=No
 
     # Function for validating an individual field
     def field_converter(field, value, context):
-        return field.validate(value, context)
+        return field.validate(value, convert, context)
 
     # Loop across fields and coerce values
     try:

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -34,8 +34,8 @@ def test_to_primitive():
 def test_validate_id():
     oid = ObjectIdType()
 
-    assert oid.validate_id(FAKE_OID) is True
-    assert oid.validate_id(str(FAKE_OID)) is True
+    oid.validate(FAKE_OID)
+    oid.validate(str(FAKE_OID))
 
-    with pytest.raises(ValidationError):
-        oid.validate_id('foo')
+    with pytest.raises(ConversionError):
+        oid.validate('foo')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -87,7 +87,7 @@ def test_int():
 def test_int_validation():
     with pytest.raises(ConversionError):
         IntType().validate('foo')
-    assert IntType().validate(5001) == None
+    assert IntType().validate(5001) == 5001
 
 
 def test_custom_validation_functions():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -359,6 +359,12 @@ def test_model_validator_override():
     assert Child._validator_functions['bar'] is not Base._validator_functions['bar']
 
 
+def test_validate_convert():
+
+    assert IntType().validate("1") == 1
+    assert IntType().validate("foo", convert=False) == "foo"
+
+
 def test_clean_validation_messages():
     error = BaseError(["A"])
     assert error.messages == ["A"]


### PR DESCRIPTION
Validator functions are supposed to operate on native values, so
it makes sense to perform the conversion in BaseType.validate()
as opposed to the validation loop. It is now possible to invoke
`field.validate()` directly, which is especially useful for testing.

***

See #338.

Reverses the patch introduced in #339, as it's now unnecessary, but keeps the test.

