### PR TITLE
Fix NumberType.to_native()

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -3,6 +3,7 @@ import re
 import datetime
 import decimal
 import itertools
+import numbers
 import functools
 import random
 import string
@@ -459,12 +460,12 @@ class NumberType(BaseType):
     }
 
     def __init__(self, number_class, number_type,
-                 min_value=None, max_value=None, coerce=False, **kwargs):
+                 min_value=None, max_value=None, strict=False, **kwargs):
         self.number_class = number_class
         self.number_type = number_type
         self.min_value = min_value
         self.max_value = max_value
-        self.coerce = coerce
+        self.strict = strict
 
         super(NumberType, self).__init__(**kwargs)
 
@@ -479,10 +480,11 @@ class NumberType(BaseType):
         except (TypeError, ValueError):
             pass
         else:
-            if (self.number_class is float  # Float conversion is strict enough.
-              or native_value == value      # Match numeric types.
-              or str(native_value) == value # Match numeric strings.
-              or self.coerce):
+            if self.number_class is float:  # Float conversion is strict enough.
+                return native_value
+            if not self.strict and native_value == value: # Match numeric types.
+                return native_value
+            if isinstance(value, (basestring, numbers.Integral)):
                 return native_value
 
         raise ConversionError(self.messages['number_coerce']

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -89,9 +89,9 @@ def test_int():
     # from string
     assert i("3") == (3, int)
     with pytest.raises(ConversionError):
-        intfield("3.0")
+        i("3.0")
     with pytest.raises(ConversionError):
-        intfield("a")
+        i("a")
     # from decimal
     assert i(Decimal("3")) == (3, int)
     assert i(Decimal("3.0")) == (3, int)
@@ -103,21 +103,32 @@ def test_int():
         i(Fraction(7, 2))
     # from uuid
     with pytest.raises(ConversionError):
-        intfield(_uuid)
+        i(_uuid)
 
 
-def test_int_coerce():
-    intfield = IntType(coerce=True)
-    assert intfield(3.0) == 3
-    assert intfield(3.2) == 3
-    assert intfield("3") == 3
+def test_int_strict():
+    intfield = IntType(strict=True)
+    i = lambda x: (intfield(x), type(intfield(x)))
+    # from int
+    assert i(3) == (3, int)
+    # from float
     with pytest.raises(ConversionError):
-        intfield("3.0")
-    assert intfield(Decimal("3")) == 3
-    assert intfield(Decimal("3.2")) == 3
-    assert intfield(Fraction(3)) == 3
-    assert intfield(Fraction(7, 2)) == 3
-    assert intfield(_uuid) == int(_uuid)
+        i(3.0)
+    # from string
+    assert i("3") == (3, int)
+    with pytest.raises(ConversionError):
+        i("3.0")
+    # from decimal
+    with pytest.raises(ConversionError):
+        assert i(Decimal("3")) == (3, int)
+    with pytest.raises(ConversionError):
+        assert i(Decimal("3.0")) == (3, int)
+    # from fraction
+    with pytest.raises(ConversionError):
+        assert i(Fraction(30, 10)) == (3, int)
+    # from uuid
+    with pytest.raises(ConversionError):
+        i(_uuid)
 
 
 def test_float():
@@ -132,7 +143,7 @@ def test_float():
     assert f("3.2") == (3.2, float)
     assert f("3.210987e6") == (3210987, float)
     with pytest.raises(ConversionError):
-        floatfield("a")
+        f("a")
     # from decimal
     assert f(Decimal("3")) == (3.0, float)
     assert f(Decimal("3.2")) == (3.2, float)
@@ -140,7 +151,7 @@ def test_float():
     assert f(Fraction(7, 2)) == (3.5, float)
     # from uuid
     with pytest.raises(ConversionError):
-        floatfield(_uuid)
+        f(_uuid)
 
 
 def test_int_validation():


### PR DESCRIPTION
This I think is a bona fide bug:

```python
>>> IntType().to_native(2.999)
2
```

That can't be by design, right?

As an aside, what do we need `LongType` for? Even in Python 2.6 integers become longs as needed:

```python
>>> int(987358972389723895234234234897)
987358972389723895234234234897L
```
