### PR TITLE
Correctly decode bytestrings in Python 3

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -21,23 +21,11 @@ except ImportError:
 
 try:
     basestring #PY2
+    bytes = str
 except NameError:
     basestring = str #PY3
+    unicode = str
 
-try:
-    unicode #PY2
-except:
-    import codecs
-    unicode = str #PY3
-
-def utf8_decode(s):
-
-    if six.PY3:
-        s = str(s) #todo: right thing to do?
-    else:
-        s = unicode(s, 'utf-8')
-
-    return s
 
 def fill_template(template, min_length, max_length):
     return template % random_string(
@@ -46,18 +34,6 @@ def fill_template(template, min_length, max_length):
             max_length,
             padding=len(template) - 2,
             required_length=1))
-
-
-def force_unicode(obj, encoding='utf-8'):
-    if isinstance(obj, basestring):
-        if not isinstance(obj, unicode):
-            #obj = unicode(obj, encoding)
-            obj = utf8_decode(obj)
-    elif not obj is None:
-        #obj = unicode(obj)
-        obj = utf8_decode(obj)
-
-    return obj
 
 
 def get_range_endpoints(min_length, max_length, padding=0, required_length=0):
@@ -329,7 +305,7 @@ class StringType(BaseType):
     accept empty strings, init with ``min_length`` 0.
     """
 
-    allow_casts = (int, str)
+    allow_casts = (int, bytes)
 
     MESSAGES = {
         'convert': u"Couldn't interpret '{0}' as string.",
@@ -354,9 +330,10 @@ class StringType(BaseType):
 
         if not isinstance(value, unicode):
             if isinstance(value, self.allow_casts):
-                if not isinstance(value, str):
-                    value = str(value)
-                value = utf8_decode(value) #unicode(value, 'utf-8')
+                if isinstance(value, bytes):
+                    value = unicode(value, 'utf-8')
+                else:
+                    value = unicode(value)
             else:
                 raise ConversionError(self.messages['convert'].format(value))
 
@@ -822,7 +799,7 @@ class MultilingualStringType(BaseType):
 
     """
 
-    allow_casts = (int, str)
+    allow_casts = (int, bytes)
 
     MESSAGES = {
         'convert': u"Couldn't interpret value as string.",
@@ -893,10 +870,10 @@ class MultilingualStringType(BaseType):
 
         if not isinstance(localized, unicode):
             if isinstance(localized, self.allow_casts):
-                if not isinstance(localized, str):
-                    localized = str(localized)
-                #localized = unicode(localized, 'utf-8')
-                localized = utf8_decode(localized)
+                if isinstance(localized, bytes):
+                    localized = unicode(localized, 'utf-8')
+                else:
+                    localized = unicode(localized)
             else:
                 raise ConversionError(self.messages['convert'])
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+
 import datetime
 import decimal
 import random
+import sys
 import uuid
 
 import pytest
@@ -8,7 +11,7 @@ import pytest
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
     URLType, MultilingualStringType, UUIDType, IPv4Type, MD5Type, BooleanType,
-    GeoPointType, FloatType, DecimalType, force_unicode
+    GeoPointType, FloatType, DecimalType
 )
 from schematics.types.base import get_range_endpoints
 from schematics.exceptions import (
@@ -173,8 +176,16 @@ def test_string_regex():
 
 
 def test_string_to_native():
+
     with pytest.raises(ConversionError):
         StringType().to_native(3.14)
+
+    if sys.version_info[0] == 2:
+        assert StringType().to_native(u'abc éíçßµ') == u'abc éíçßµ'
+        assert StringType().to_native('\xC3\xA4') == u'ä'
+    else:
+        assert StringType().to_native('abc éíçßµ') == 'abc éíçßµ'
+        assert StringType().to_native(b'\xC3\xA4') == 'ä'
 
 
 def test_string_max_length_is_enforced():


### PR DESCRIPTION
Fixes and simplifies Unicode routines. Also adds tests which were
notably absent.

***

##### Before patch

Python 2:

```python
>>> StringType()('\xc3\xa4').encode('utf-8')
'\xc3\xa4'
```

Python 3:

```python
>>> StringType()(b'\xc3\xa4').encode('utf-8')
Traceback (most recent call last):
  ...
schematics.exceptions.ConversionError: ["Couldn't interpret 'b'\\xc3\\xa4'' as string."]
```
