### PR TITLE
Unify import/export interface across all types

### DIFF
--- a/schematics/common.py
+++ b/schematics/common.py
@@ -1,0 +1,6 @@
+
+NATIVE, PRIMITIVE = 0, 1
+
+EMPTY_LIST = "[]"
+EMPTY_DICT = "{}"
+

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -5,8 +5,10 @@ import itertools
 
 from six import iteritems
 
-from .datastructures import OrderedDict, get_context_factory
+from .common import NATIVE, PRIMITIVE, EMPTY_LIST, EMPTY_DICT
+from .datastructures import OrderedDict, get_context_factory, DataObject
 from .exceptions import ConversionError, ModelConversionError, ValidationError
+from .types.compound import ModelType
 
 try:
     basestring #PY2
@@ -32,13 +34,13 @@ except:
 ###
 
 ImportContext = get_context_factory('ImportContext',
-                    'partial, strict, mapping, app_data')
+                    'field_converter, partial, strict, mapping, app_data')
 
 ExportContext = get_context_factory('ExportContext',
-                    'role, raise_error_on_role, print_none, app_data')
+                    'field_converter, role, raise_error_on_role, print_none, app_data')
 
 
-def import_loop(cls, instance_or_dict, field_converter, trusted_data=None,
+def import_loop(cls, instance_or_dict, field_converter=None, trusted_data=None,
                 partial=False, strict=False, mapping=None, app_data=None, context=None):
     """
     The import loop is designed to take untrusted data and convert it into the
@@ -74,7 +76,7 @@ def import_loop(cls, instance_or_dict, field_converter, trusted_data=None,
 
     mapping = mapping or {}
     app_data = app_data if app_data is not None else {}
-    context = context or ImportContext(partial, strict, mapping, app_data)
+    context = context or ImportContext(field_converter, partial, strict, mapping, app_data)
 
     data = dict(trusted_data) if trusted_data else {}
     errors = {}
@@ -136,8 +138,8 @@ def import_loop(cls, instance_or_dict, field_converter, trusted_data=None,
     return data
 
 
-def export_loop(cls, instance_or_dict, field_converter, role=None, 
-                raise_error_on_role=False, print_none=False, app_data=None, context=None):
+def export_loop(cls, instance_or_dict, field_converter=None, role=None,
+                raise_error_on_role=True, print_none=False, app_data=None, context=None):
     """
     The export_loop function is intended to be a general loop definition that
     can be used for any form of data shaping, such as application of roles or
@@ -169,7 +171,7 @@ def export_loop(cls, instance_or_dict, field_converter, role=None,
         of ``export_loop`` and is then propagated through the entire process.
     """
     app_data = app_data if app_data is not None else {}
-    context = context or ExportContext(role, raise_error_on_role, print_none, app_data)
+    context = context or ExportContext(field_converter, role, raise_error_on_role, print_none, app_data)
 
     data = {}
 
@@ -195,8 +197,8 @@ def export_loop(cls, instance_or_dict, field_converter, role=None,
 
         # Value found, apply transformation and store it
         elif value is not None:
-            shaped = field_converter(field, value, context)
-            feels_empty = shaped is None or isinstance(field, MultiType) and len(shaped) == 0
+            shaped = context.field_converter(field, value, context)
+            feels_empty = shaped is None or field.is_compound and len(shaped) == 0
 
             # Print if we want none or found a value
             if feels_empty:
@@ -422,54 +424,48 @@ def blacklist(*field_list):
 ###
 
 
-def convert(cls, instance_or_dict, trusted_data=None, partial=True, strict=False,
-            mapping=None, app_data=None, context=None):
-    field_converter = lambda field, value, context: field.to_native(value, context)
-    data = import_loop(cls, instance_or_dict, field_converter, trusted_data=trusted_data,
-                       partial=partial, strict=strict, mapping=mapping, app_data=app_data, context=context)
-    return data
+class FieldConverter(object):
+
+    def __call__(self, field, value, context):
+        raise NotImplementedError
 
 
-def to_native(cls, instance_or_dict, role=None, raise_error_on_role=True, app_data=None, context=None):
-    field_converter = lambda field, value, context: field.to_native(value, context)
-    data = export_loop(cls, instance_or_dict, field_converter, role=role,
-                       raise_error_on_role=raise_error_on_role, app_data=app_data, context=context)
-    return data
+class ExportConverter(FieldConverter):
+
+    def __init__(self, format, exceptions=None):
+        self.primary = format
+        self.secondary = not format
+        self.exceptions = set(exceptions) if exceptions else None
+
+    def __call__(self, field, value, context):
+        format = self.primary
+        if self.exceptions:
+            if any((issubclass(field.typeclass, cls) for cls in self.exceptions)):
+                format = self.secondary
+        return field.export(value, format, context)
 
 
-def to_primitive(cls, instance_or_dict, role=None, raise_error_on_role=True, app_data=None, context=None):
-    """
-    Implements serialization as a mechanism to convert ``Model`` instances into
-    dictionaries keyed by field_names with the converted data as the values.
+_import_converter = lambda field, value, context: field.convert(value, context)
 
-    The conversion is done by calling ``to_primitive`` on both model and field
-    instances.
-
-    :param cls:
-        The model definition.
-    :param instance_or_dict:
-        The structure where fields from cls are mapped to values. The only
-        expectionation for this structure is that it implements a ``dict``
-        interface.
-    :param role:
-        The role used to determine if fields should be left out of the
-        transformation.
-    :param raise_error_on_role:
-        This parameter enforces strict behavior which requires substructures
-        to have the same role definition as their parent structures.
-    """
-    field_converter = lambda field, value, context: field.to_primitive(value, context)
-    data = export_loop(cls, instance_or_dict, field_converter, role=role,
-                       raise_error_on_role=raise_error_on_role, app_data=app_data, context=context)
-    return data
+_to_native_converter = ExportConverter(NATIVE)
+_to_dict_converter = ExportConverter(NATIVE, [ModelType])
+_to_primitive_converter = ExportConverter(PRIMITIVE)
 
 
-def serialize(cls, instance_or_dict, role=None, raise_error_on_role=True, app_data=None, context=None):
-    return to_primitive(cls, instance_or_dict, role, raise_error_on_role, app_data, context)
+def convert(cls, instance_or_dict, **kwargs):
+    return import_loop(cls, instance_or_dict, _import_converter, **kwargs)
 
 
-EMPTY_LIST = "[]"
-EMPTY_DICT = "{}"
+def to_native(cls, instance_or_dict, **kwargs):
+    return export_loop(cls, instance_or_dict, _to_native_converter, **kwargs)
+
+
+def to_dict(cls, instance_or_dict, **kwargs):
+    return export_loop(cls, instance_or_dict, _to_dict_converter, **kwargs)
+
+
+def to_primitive(cls, instance_or_dict, **kwargs):
+    return export_loop(cls, instance_or_dict, _to_primitive_converter, **kwargs)
 
 
 def expand(data, expanded_data=None):
@@ -600,15 +596,10 @@ def flatten(cls, instance_or_dict, role=None, raise_error_on_role=True,
         This puts a prefix in front of the field names during flattening.
         Default: None
     """
-    field_converter = lambda field, value, context: field.to_primitive(value, context)
-
-    data = export_loop(cls, instance_or_dict, field_converter, role=role,
-                       raise_error_on_role=raise_error_on_role, print_none=True,
-                       app_data=app_data, context=context)
+    data = to_primitive(cls, instance_or_dict, role=role, raise_error_on_role=raise_error_on_role,
+                        print_none=True, app_data=app_data, context=context)
 
     flattened = flatten_to_dict(data, prefix=prefix, ignore_none=ignore_none)
 
     return flattened
 
-
-from .types.compound import MultiType

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -195,12 +195,8 @@ def export_loop(cls, instance_or_dict, field_converter, role=None,
 
         # Value found, apply transformation and store it
         elif value is not None:
-            if hasattr(field, 'export_loop'):
-                shaped = field.export_loop(value, field_converter, context)
-                feels_empty = shaped is None or len(shaped) == 0
-            else:
-                shaped = field_converter(field, value, context)
-                feels_empty = shaped is None
+            shaped = field_converter(field, value, context)
+            feels_empty = shaped is None or isinstance(field, MultiType) and len(shaped) == 0
 
             # Print if we want none or found a value
             if feels_empty:

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -43,8 +43,10 @@ class Serializable(object):
     def __init__(self, func, type=None, serialized_name=None, serialize_when_none=True):
         self.func = func
         self.type = type
+        self.typeclass = type.__class__
         self.serialized_name = serialized_name
         self.serialize_when_none = serialize_when_none
+        self.is_compound = self.type.is_compound
 
     def __get__(self, instance, cls):
         if instance:
@@ -52,8 +54,9 @@ class Serializable(object):
         else:
             return self
 
-    def to_native(self, value, context=None):
-        return self.type.to_native(value, context)
+    def convert(self, value, context=None):
+        return self.type.convert(value, context)
 
-    def to_primitive(self, value, context=None):
-        return self.type.to_primitive(value, context)
+    def export(self, value, target, context=None):
+        return self.type.export(value, target, context)
+

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -46,13 +46,6 @@ class Serializable(object):
         self.serialized_name = serialized_name
         self.serialize_when_none = serialize_when_none
 
-        if hasattr(type, 'export_loop'):
-            def make_export_loop(_type):
-                def export_loop(*args, **kwargs):
-                    return _type.export_loop(*args, **kwargs)
-                return export_loop
-            self.export_loop = make_export_loop(self.type)
-
     def __get__(self, instance, cls):
         if instance:
             return self.func(instance)

--- a/tests/test_compound.py
+++ b/tests/test_compound.py
@@ -3,6 +3,6 @@ import pytest
 from schematics.types.compound import MultiType
 
 
-def test_base_does_not_implement_export_loop():
+def test_base_does_not_implement_export():
     with pytest.raises(NotImplementedError):
-        MultiType().export_loop(None, None, None)
+        MultiType().export(None, None, None)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from schematics.models import Model
+from schematics.transforms import ExportConverter
+from schematics.types import *
+from schematics.types.compound import *
+from schematics.types.serializable import serializable
+
+
+class BaseModel(Model):
+    pass
+
+class N(BaseModel):
+    floatfield = FloatType()
+    uuidfield = UUIDType()
+
+class M(BaseModel):
+    intfield = IntType()
+    stringfield = StringType()
+    dtfield = DateTimeType()
+    utcfield = UTCDateTimeType()
+    modelfield = ModelType(N)
+
+
+input = { 'intfield': 3,
+          'stringfield': 'foobar',
+          'dtfield': '2015-11-26T09:00:00.000000',
+          'utcfield': '2015-11-26T07:00:00.000000Z',
+          'modelfield': {
+              'floatfield': 1.0,
+              'uuidfield': '54020382-291e-4192-b370-4850493ac5bc' }}
+
+natives = { 'intfield': 3,
+            'stringfield': 'foobar',
+            'dtfield': datetime.datetime(2015, 11, 26, 9),
+            'utcfield': datetime.datetime(2015, 11, 26, 7),
+            'modelfield': { 
+                'floatfield': 1.0,
+                'uuidfield': uuid.UUID('54020382-291e-4192-b370-4850493ac5bc') }}
+
+
+def test_to_native():
+
+    m = M(input)
+
+    assert m.to_native() == m
+
+    _natives = natives.copy()
+    assert m._data.pop('modelfield')._data == _natives.pop('modelfield')
+    assert m._data == _natives
+
+
+def test_to_dict():
+
+    m = M(input)
+    assert m.to_dict() == natives
+
+
+def test_to_primitive():
+
+    m = M(input)
+    assert m.to_primitive() == input
+
+
+def test_custom_exporter():
+
+    class Foo(object):
+        def __init__(self, x, y):
+            self.x, self.y = x, y
+        def __eq__(self, other):
+            return self.x == other.x and self.y == other.y
+
+    class FooType(BaseType):
+        def to_native(self, value, context):
+            if isinstance(value, Foo):
+                return value
+            return Foo(value['x'], value['y'])
+        def to_primitive(self, value, context):
+            return dict(x=value.x, y=value.y)
+
+    class M(Model):
+        id = UUIDType()
+        dt = UTCDateTimeType()
+        foo = FooType()
+
+    m = M({ 'id': '54020382-291e-4192-b370-4850493ac5bc',
+            'dt': '2015-11-26T07:00',
+            'foo': {'x': 1, 'y': 2} })
+
+    assert m.to_dict() == {
+        'id': uuid.UUID('54020382-291e-4192-b370-4850493ac5bc'),
+        'dt': datetime.datetime(2015, 11, 26, 7),
+        'foo': Foo(1, 2) }
+
+    exporter = ExportConverter(PRIMITIVE, [UTCDateTimeType, UUIDType])
+
+    assert m.export(PRIMITIVE, field_converter=exporter) == {
+        'id': uuid.UUID('54020382-291e-4192-b370-4850493ac5bc'),
+        'dt': datetime.datetime(2015, 11, 26, 7),
+        'foo': {'x': 1, 'y': 2} }
+
+

--- a/tests/test_ordered_serialization.py
+++ b/tests/test_ordered_serialization.py
@@ -15,7 +15,7 @@ def test_serialize_field_orders_one_two_three():
 
     p1 = Example({'one': 'a', 'two': 2, 'three': '3'})
     order = [('one', 'a'), ('two', 2), ('three', '3')]
-    serialized = p1.to_native()
+    serialized = p1.to_dict()
     assert serialized.items() == order
 
 
@@ -29,7 +29,7 @@ def test_serialize_field_orders_three_two_one():
             fields_order = ['three', 'two', 'one']
 
     p1 = Example({'one': 'a', 'two': 2, 'three': '3'})
-    serialized = p1.to_native()
+    serialized = p1.to_dict()
     order = [('three', '3'), ('two', 2), ('one', 'a')]
     assert serialized.items() == order
 
@@ -44,6 +44,6 @@ def test_serialize_field_orders_one_three_two():
             fields_order = ['one', 'three', 'two']
 
     p1 = Example({'one': 'a', 'two': 2, 'three': '3'})
-    serialized = p1.to_native()
+    serialized = p1.to_dict()
     order = [('one', 'a'), ('three', '3'), ('two', 2)]
     assert serialized.items() == order

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -30,7 +30,7 @@ def test_serializable():
     d = location_US.serialize()
     assert d == {"country_code": "US", "country_name": "United States"}
 
-    d = location_US.to_native()
+    d = location_US.to_dict()
     assert d == {"country_code": u"US", "country_name": "United States"}
 
     location_IS = Location({"country_code": "IS"})
@@ -40,11 +40,11 @@ def test_serializable():
     d = location_IS.serialize()
     assert d == {"country_code": "IS", "country_name": "Unknown"}
 
-    d = location_IS.to_native()
+    d = location_IS.to_dict()
     assert d == {"country_code": "IS", "country_name": "Unknown"}
 
 
-def test_serializable_to_native():
+def test_serializable_to_dict():
     class Location(Model):
         country_code = StringType()
 
@@ -54,7 +54,7 @@ def test_serializable_to_native():
 
     loc = Location({'country_code': 'US'})
 
-    d = loc.to_native()
+    d = loc.to_dict()
     assert d == {'country_code': 'US', 'country_name': 'United States'}
 
 
@@ -116,7 +116,7 @@ def test_serializable_with_model():
     assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
 
 
-def test_serializable_with_model_to_native():
+def test_serializable_with_model_to_dict():
     class ExperienceLevel(Model):
         level = IntType()
         title = StringType()
@@ -132,7 +132,7 @@ def test_serializable_with_model_to_native():
 
     assert player.xp_level.level == 4
 
-    d = player.to_native()
+    d = player.to_dict()
     assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
 
 


### PR DESCRIPTION
This is based on the ideas I talked about [here](https://github.com/schematics/schematics/issues/337#issuecomment-157871276) and [here](https://github.com/schematics/schematics/issues/324#issuecomment-155924477). The patch standardizes on methods called `convert` and `export`:

```python
def convert(self, value, context):
    # import and convert to native
```
```python
def export(self, value, format, context):
    # export according to format
```

where `format` is either `PRIMITIVE` or `NATIVE` (or a custom format; a type could choose to support more than these two).

Compound types implement these methods directly, while basic types can just map them to `to_native` and `to_primitive` as appropriate.

The bundled compound types no longer have any concept of primitive vs. native, as it makes no difference to them.

### Field converters

The overhaul gets rid of the famous `hasattr(field, 'export_loop')` conditionals. Now `export_loop` can just apply `field_converter` to every field and not care about what it does.

The fact that everything now passes through the field converter function opens up all kinds of possibilities for customizing the export process. To make this capability more prominent, `transforms.py` now defines the field converter interface:

```python
class FieldConverter(object):
    def __call__(self, field, value, context):
        raise NotImplementedError
```

The module includes a basic implementation that also supports mixed representations as described below.

### Mixed formats

In [this comment](https://github.com/schematics/schematics/issues/366#issuecomment-159982673) I provided a rationale for mixed representations, where some fields would be output as native and others as primitives. My initial plan was to introduce an "export profile" object that would have encapsulated this information.

However, since ultimately the field converter is in charge of the code that would query the export profile, it made sense to simply assign this responsibility to the field converter and not specify the details.

The bundled `ExportConverter` class supports configurations like "export everything as native except types *x*, *y*, and *z* as primitive" and vice versa.

### Compatibility

Basic types continue to work without modifications. The mapping from `field.export()` and `field.convert()` to the actual conversion methods is taken care of by `BaseType` unless overridden.

`Model.to_native()` used to return a mixed representation where models were converted to dictionaries but everything else remained in its native form. This behavior is now available as `Model.to_dict()`. The new `Model.to_native()` runs the export loop and applies roles but returns an instance, not a `dict`.

