### PR TITLE
Serializable improvements

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -154,6 +154,8 @@ class ModelMeta(type):
         fields.sort(key=lambda i: i[1]._position_hint)
         for key, field in iteritems(fields):
             attrs[key] = FieldDescriptor(key)
+        for key, serializable in iteritems(serializables):
+            attrs[key] = serializable
 
         # Ready meta data to be klass attributes
         attrs['_fields'] = fields

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -172,6 +172,8 @@ class ModelMeta(type):
         # Finalize fields
         for field_name, field in fields.items():
             field._setup(field_name, klass)
+        for field_name, field in serializables.items():
+            field._setup(field_name, klass)
 
         return klass
 

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import, division
+
+try:
+    basestring #PY2
+    bytes = str
+    range = xrange
+except NameError:
+    basestring = str #PY3
+    unicode = str
+
+
+def setdefault(obj, attr, value, search_mro=False, overwrite_none=False):
+    if search_mro:
+        exists = hasattr(obj, attr)
+    else:
+        exists = attr in obj.__dict__
+    if exists and overwrite_none:
+        if getattr(obj, attr) is None:
+            exists = False
+    if exists:
+        value = getattr(obj, attr)
+    else:
+        setattr(obj, attr, value)
+    return value
+

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -113,3 +113,41 @@ def test_serializable_doesnt_keep_global_state():
 
     assert id(location_US._serializables["country_name"]) == id(
         location_IS._serializables["country_name"])
+
+
+def test_field_inheritance():
+
+    class A(Model):
+        field1 = StringType()
+        field2 = StringType()
+
+    class B(A):
+        field2 = StringType(required=True)
+        field3 = StringType()
+
+    assert A.field1 is A._fields['field1'] is not B._fields['field1']
+    assert A.field2 is A._fields['field2'] is not B._fields['field2']
+    assert 'field3' not in A._fields
+
+    assert B.field1 is B._fields['field1']
+    assert B.field2 is B._fields['field2']
+    assert B.field3 is B._fields['field3']
+
+    assert A.field2.required is False and B.field2.required is True
+
+
+def test_serializable_inheritance():
+
+    class A(Model):
+        @serializable
+        def s(self):
+            pass
+
+    class B(A):
+        pass
+
+    assert A.s is A._serializables['s'] is not B._serializables['s']
+    assert B.s is B._serializables['s']
+    assert A.s.type is not B.s.type
+    assert A.s.func is B.s.func
+


### PR DESCRIPTION
So it turns out `ModelMeta` has been giving subclasses their own copies of base class serializables, but the copies have never been invoked. The serializables have been added to the `_serializables` dict but never set as actual attributes. Lookups would therefore reach the parent class. This is now fixed.

The patch also cleans things up by eliminating most attributes on serializables. Lookups are delegated to the underlying type through `__getattr__()`. This way, the `Serializable` class doesn't have to be updated every time a new attribute is added to `BaseType`.

Finally, the type argument to the `serializable` decorator can now be either a class or an instance.
