### PR TITLE
Add support for undefined values

### DIFF
--- a/schematics/common.py
+++ b/schematics/common.py
@@ -1,5 +1,14 @@
+from .util import Constant
 
-NATIVE, PRIMITIVE = 0, 1
+
+NATIVE    = Constant('NATIVE',     0)
+PRIMITIVE = Constant('PRIMITIVE',  1)
+
+DROP      = Constant('DROP',       0)
+NONEMPTY  = Constant('NONEMPTY',   1)
+NOT_NONE  = Constant('NOT_NONE',   2)
+DEFAULT   = Constant('DEFAULT',   10)
+ALL       = Constant('ALL',       99)
 
 EMPTY_LIST = "[]"
 EMPTY_DICT = "{}"

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -59,3 +59,14 @@ class StopValidation(ValidationError):
 class MockCreationError(ValueError):
     """Exception raised when a mock value cannot be generated."""
     pass
+
+
+class MissingValueError(AttributeError, KeyError):
+    """Exception raised when accessing an undefined value on an instance."""
+    pass
+
+
+class UnknownFieldError(KeyError):
+    """Exception raised when attempting to set a nonexistent field using the subscription syntax."""
+    pass
+

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -237,7 +237,7 @@ class Model(object):
     def __init__(self, raw_data=None, trusted_data=None, deserialize_mapping=None,
                  partial=True, strict=True, init_values=True, app_data=None, **kwargs):
 
-        self._initial = raw_data = raw_data or {}
+        self._initial = raw_data or {}
         self._data = self.convert(raw_data,
                                   trusted_data=trusted_data, mapping=deserialize_mapping,
                                   partial=partial, strict=strict, init_values=init_values,

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -8,7 +8,7 @@ from six import iteritems
 from six import iterkeys
 from six import add_metaclass
 
-from .common import NATIVE, PRIMITIVE
+from .common import *
 from .datastructures import OrderedDict as OrderedDictWithSort
 from .exceptions import (
     BaseError, ModelValidationError, MockCreationError,
@@ -83,7 +83,7 @@ class ModelOptions(object):
     instance of a model.
     """
 
-    def __init__(self, klass, namespace=None, roles=None, export_level=3,
+    def __init__(self, klass, namespace=None, roles=None, export_level=DEFAULT,
                  serialize_when_none=None, fields_order=None):
         """
         :param klass:
@@ -105,9 +105,9 @@ class ModelOptions(object):
         self.roles = roles or {}
         self.export_level = export_level
         if serialize_when_none is True:
-            self.export_level = 3
+            self.export_level = DEFAULT
         elif serialize_when_none is False:
-            self.export_level = 1
+            self.export_level = NONEMPTY
         self.fields_order = fields_order
 
 

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -264,7 +264,7 @@ def atoms(cls, instance_or_dict):
     all_fields = itertools.chain(iteritems(cls._fields),
                                  iteritems(cls._serializables))
 
-    return ((field_name, field, instance_or_dict[field_name])
+    return ((field_name, field, instance_or_dict.get(field_name, Undefined))
             for field_name, field in all_fields)
 
 

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -8,7 +8,7 @@ from six import iteritems
 from .common import NATIVE, PRIMITIVE, EMPTY_LIST, EMPTY_DICT
 from .datastructures import OrderedDict, get_context_factory, DataObject
 from .exceptions import ConversionError, ModelConversionError, ValidationError
-from .types.compound import ModelType
+from .undefined import Undefined
 
 try:
     basestring #PY2
@@ -34,14 +34,15 @@ except:
 ###
 
 ImportContext = get_context_factory('ImportContext',
-                    'field_converter, partial, strict, mapping, app_data')
+    'field_converter, mapping, partial, strict, init_values, apply_defaults, app_data')
 
 ExportContext = get_context_factory('ExportContext',
-                    'field_converter, role, raise_error_on_role, print_none, app_data')
+    'field_converter, role, raise_error_on_role, export_level, app_data')
 
 
 def import_loop(cls, instance_or_dict, field_converter=None, trusted_data=None,
-                partial=False, strict=False, mapping=None, app_data=None, context=None):
+                mapping=None, partial=False, strict=False, init_values=False,
+                apply_defaults=None, app_data=None, context=None):
     """
     The import loop is designed to take untrusted data and convert it into the
     native types, as described in ``cls``.  It does this by calling
@@ -63,6 +64,9 @@ def import_loop(cls, instance_or_dict, field_converter=None, trusted_data=None,
         definitions. Default: False
     :param strict:
         Complain about unrecognized keys. Default: False
+    :param apply_defaults:
+        Whether to set fields to their default values when not present in input data.
+        If this parameter is not provided, defaults are applied when ``partial=False``.
     :param app_data:
         An arbitrary container for application-specific data that needs to
         be available during the conversion.
@@ -76,7 +80,14 @@ def import_loop(cls, instance_or_dict, field_converter=None, trusted_data=None,
 
     mapping = mapping or {}
     app_data = app_data if app_data is not None else {}
-    context = context or ImportContext(field_converter, partial, strict, mapping, app_data)
+    context = context or ImportContext(field_converter, mapping, partial, strict,
+                                       init_values, apply_defaults, app_data)
+
+    if context.apply_defaults is None:
+        _apply_defaults = context.init_values
+    else:
+        _apply_defaults = context.apply_defaults
+
 
     data = dict(trusted_data) if trusted_data else {}
     errors = {}
@@ -106,26 +117,29 @@ def import_loop(cls, instance_or_dict, field_converter=None, trusted_data=None,
             serialized_field_name = field_name
             trial_keys.append(field_name)
 
-        raw_value = None
+        value = Undefined
         for key in trial_keys:
             if key and key in instance_or_dict:
-                raw_value = instance_or_dict[key]
-        if raw_value is None:
+                value = instance_or_dict[key]
+        if value is Undefined:
             if field_name in data:
                 continue
-            raw_value = field.default
+            if _apply_defaults:
+                value = field.default
+        if value is Undefined and context.init_values:
+            value = None
 
         try:
-            if raw_value is None:
+            if value in (None, Undefined):
                 if field.required and not context.partial:
                     errors[serialized_field_name] = [field.messages['required']]
             else:
                 field_params = {
                     'mapping': context.mapping.get('model_mapping', {}).get(field_name, None)
                 }
-                raw_value = field_converter(field, raw_value, context._branch(**field_params))
+                value = field_converter(field, value, context._branch(**field_params))
 
-            data[field_name] = raw_value
+            data[field_name] = value
 
         except ConversionError as exc:
             errors[serialized_field_name] = exc.messages
@@ -138,8 +152,8 @@ def import_loop(cls, instance_or_dict, field_converter=None, trusted_data=None,
     return data
 
 
-def export_loop(cls, instance_or_dict, field_converter=None, role=None,
-                raise_error_on_role=True, print_none=False, app_data=None, context=None):
+def export_loop(cls, instance_or_dict, field_converter=None, role=None, raise_error_on_role=True,
+                export_level=None, app_data=None, context=None):
     """
     The export_loop function is intended to be a general loop definition that
     can be used for any form of data shaping, such as application of roles or
@@ -159,9 +173,6 @@ def export_loop(cls, instance_or_dict, field_converter=None, role=None,
     :param raise_error_on_role:
         This parameter enforces strict behavior which requires substructures
         to have the same role definition as their parent structures.
-    :param print_none:
-        This function overrides ``serialize_when_none`` values found either on
-        ``cls`` or an instance.
     :param app_data:
         An arbitrary container for application-specific data that needs to
         be available during the conversion.
@@ -171,7 +182,7 @@ def export_loop(cls, instance_or_dict, field_converter=None, role=None,
         of ``export_loop`` and is then propagated through the entire process.
     """
     app_data = app_data if app_data is not None else {}
-    context = context or ExportContext(field_converter, role, raise_error_on_role, print_none, app_data)
+    context = context or ExportContext(field_converter, role, raise_error_on_role, export_level, app_data)
 
     data = {}
 
@@ -195,21 +206,19 @@ def export_loop(cls, instance_or_dict, field_converter=None, role=None,
         if gottago(field_name, value):
             continue
 
-        # Value found, apply transformation and store it
-        elif value is not None:
-            shaped = context.field_converter(field, value, context)
-            feels_empty = shaped is None or field.is_compound and len(shaped) == 0
+        if field.get_export_level(context) == 0:
+            continue
 
-            # Print if we want none or found a value
-            if feels_empty:
-                if allow_none(cls, field) or context.print_none:
-                    data[serialized_name] = shaped
-            elif shaped is not None:
-                data[serialized_name] = shaped
+        elif value not in (None, Undefined):
+            value = context.field_converter(field, value, context)
 
-        # Store None if reqeusted
-        elif allow_none(cls, field) or context.print_none:
-            data[serialized_name] = value
+        if export_filter(field, value, context):
+            continue
+
+        if value is Undefined:
+            value = None
+
+        data[serialized_name] = value
 
     if fields_order:
         data = sort_dict(data, fields_order)
@@ -257,25 +266,6 @@ def atoms(cls, instance_or_dict):
 
     return ((field_name, field, instance_or_dict[field_name])
             for field_name, field in all_fields)
-
-
-def allow_none(cls, field):
-    """
-    This function inspects a model and a field for a setting either at the
-    model or field level for the ``serialize_when_none`` setting.
-
-    The setting defaults to the value of the class.  A field can override the
-    class setting with it's own ``serialize_when_none`` setting.
-
-    :param cls:
-        The model definition.
-    :param field:
-        The field in question.
-    """
-    allowed = cls._options.serialize_when_none
-    if field.serialize_when_none is not None:
-        allowed = field.serialize_when_none
-    return allowed
 
 
 ###
@@ -419,9 +409,30 @@ def blacklist(*field_list):
     return Role(Role.blacklist, field_list)
 
 
+def export_filter(field, value, context):
+
+    export_level = field.get_export_level(context)
+    if export_level == 0:
+        return True
+
+    if value is Undefined:
+        if export_level <= 3:
+            return True
+    elif value is None:
+        if export_level <= 2:
+            return True
+    elif field.is_compound and len(value) == 0:
+        if export_level <= 1:
+            return True
+
+    return False
+
+
 ###
 # Import and export functions
 ###
+
+from .types.compound import ModelType
 
 
 class FieldConverter(object):
@@ -597,7 +608,7 @@ def flatten(cls, instance_or_dict, role=None, raise_error_on_role=True,
         Default: None
     """
     data = to_primitive(cls, instance_or_dict, role=role, raise_error_on_role=raise_error_on_role,
-                        print_none=True, app_data=app_data, context=context)
+                        export_level=3, app_data=app_data, context=context)
 
     flattened = flatten_to_dict(data, prefix=prefix, ignore_none=ignore_none)
 

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -258,6 +258,10 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         validators by raising ``StopValidation`` instead of ``ValidationError``.
 
         """
+        self.check_required(value, context)
+        if value in (None, Undefined):
+            return value
+
         if convert:
             value = self.convert(value, context)
 
@@ -275,6 +279,11 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
             raise ValidationError(errors)
 
         return value
+
+    def check_required(self, value, context=None):
+        if self.required and value in (None, Undefined):
+            if self.name is None or context and not context.partial:
+                raise ValidationError(self.messages['required'])
 
     def validate_choices(self, value, context=None):
         if self.choices is not None:

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -19,6 +19,7 @@ from ..common import NATIVE, PRIMITIVE
 from ..exceptions import (
     StopValidation, ValidationError, ConversionError, MockCreationError
 )
+from ..undefined import Undefined
 
 try:
     from string import ascii_letters # PY3
@@ -160,9 +161,10 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         PRIMITIVE: 'to_primitive',
     }
 
-    def __init__(self, required=False, default=None, serialized_name=None,
+    def __init__(self, required=False, default=Undefined, serialized_name=None,
                  choices=None, validators=None, deserialize_from=None,
-                 serialize_when_none=None, messages=None):
+                 export_level=None, serialize_when_none=None,
+                 messages=None, **kwargs):
         super(BaseType, self).__init__()
         self.required = required
         self._default = default
@@ -176,7 +178,8 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         if validators:
             self.validators += validators
 
-        self.serialize_when_none = serialize_when_none
+        self._set_export_level(export_level, serialize_when_none)
+
         self.messages = dict(self.MESSAGES, **(messages or {}))
         self._position_hint = next(_next_position_hint)  # For ordering of fields
 
@@ -205,11 +208,29 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         self.name = field_name
         self.owner_model = owner_model
 
+    def _set_export_level(self, export_level, serialize_when_none):
+        if export_level is not None:
+            self.export_level = export_level
+        elif serialize_when_none is True:
+            self.export_level = 3
+        elif serialize_when_none is False:
+            self.export_level = 1
+        else:
+            self.export_level = None
+
+    def get_export_level(self, context):
+        level = self.owner_model._options.export_level
+        if self.export_level is not None:
+            level = self.export_level
+        if context.export_level is not None:
+            level = context.export_level
+        return level
+
     @property
     def default(self):
         default = self._default
-        if callable(self._default):
-            default = self._default()
+        if callable(default):
+            default = default()
         return default
 
     def convert(self, value, context=None):
@@ -228,12 +249,6 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         Convert untrusted data to a richer Python construct.
         """
         return value
-
-    def allow_none(self):
-        if self.owner_model:
-            return self.owner_model.allow_none(self)
-        else:
-            return self.serialize_when_none
 
     def validate(self, value, convert=True, context=None):
         """

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -15,7 +15,7 @@ import string
 import six
 from six import iteritems
 
-from ..common import NATIVE, PRIMITIVE
+from ..common import *
 from ..exceptions import (
     StopValidation, ValidationError, ConversionError, MockCreationError
 )
@@ -212,9 +212,9 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         if export_level is not None:
             self.export_level = export_level
         elif serialize_when_none is True:
-            self.export_level = 3
+            self.export_level = DEFAULT
         elif serialize_when_none is False:
-            self.export_level = 1
+            self.export_level = NONEMPTY
         else:
             self.export_level = None
 

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -34,6 +34,8 @@ def serializable(*args, **kwargs):
             # If `serialized_type` is already an instance, update it with the options
             # found in `kwargs`. This is necessary because historically certain options
             # were stored on the `Serializable` itself instead of the underlying field.
+            serialized_type._set_export_level(
+                kwargs.pop('export_level', None), kwargs.pop("serialize_when_none", None))
             for name, value in kwargs.items():
                 setdefault(serialized_type, name, value, overwrite_none=True)
         else:

--- a/schematics/undefined.py
+++ b/schematics/undefined.py
@@ -1,0 +1,53 @@
+class UndefinedType(object):
+
+    _instance = None
+
+    def __str__(self):
+        return 'Undefined'
+
+    def __repr__(self):
+        return 'Undefined'
+
+    def __eq__(self, other):
+        return self is other
+
+    def __ne__(self, other):
+        return self is not other
+
+    def __bool__(self):
+        return False
+
+    __nonzero__ = __bool__
+
+    def __lt__(self, other):
+        self._cmp_err(other, '<')
+
+    def __gt__(self, other):
+        self._cmp_err(other, '>')
+
+    def __le__(self, other):
+        self._cmp_err(other, '<=')
+
+    def __ge__(self, other):
+        self._cmp_err(other, '>=')
+
+    def _cmp_err(self, other, op):
+        raise TypeError("unorderable types: {0}() {1} {2}()".format(
+                        self.__class__.__name__, op, other.__class__.__name__))
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = object.__new__(cls)
+        elif cls is not UndefinedType:
+            raise TypeError("type 'UndefinedType' is not an acceptable base type")
+        return cls._instance
+
+    def __init__(self):
+        pass
+
+    def __setattr__(self, name, value):
+        raise TypeError("'UndefinedType' object does not support attribute assignment")
+
+
+Undefined = UndefinedType()
+

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -23,3 +23,17 @@ def setdefault(obj, attr, value, search_mro=False, overwrite_none=False):
         setattr(obj, attr, value)
     return value
 
+
+class Constant(int):
+
+    def __new__(cls, name, value):
+        return int.__new__(cls, value)
+
+    def __init__(self, name, value):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+    __str__ = __repr__
+

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -1,8 +1,9 @@
 from .exceptions import BaseError, ValidationError, ModelConversionError
+from .undefined import Undefined
 
 
 def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=None,
-             convert=True, app_data=None, context=None):
+             convert=True, init_values=False, context=None, **kwargs):
     """
     Validate some untrusted data using a model. Trusted data can be passed in
     the `trusted_data` parameter.
@@ -40,9 +41,9 @@ def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=No
 
     # Loop across fields and coerce values
     try:
-        data = import_loop(cls, instance_or_dict, field_converter,
-                           trusted_data=trusted_data, partial=partial, strict=strict,
-                           app_data=app_data, context=context)
+        data = import_loop(cls, instance_or_dict, field_converter, trusted_data=trusted_data,
+                           partial=partial, strict=strict, init_values=init_values,
+                           context=context, **kwargs)
     except ModelConversionError as mce:
         errors = mce.messages
 

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -2,8 +2,8 @@ from .exceptions import BaseError, ValidationError, ModelConversionError
 from .undefined import Undefined
 
 
-def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=None,
-             convert=True, init_values=False, context=None, **kwargs):
+def validate(cls, instance_or_dict, trusted_data=None, partial=False, strict=False,
+             convert=True, context=None, **kwargs):
     """
     Validate some untrusted data using a model. Trusted data can be passed in
     the `trusted_data` parameter.
@@ -42,8 +42,7 @@ def validate(cls, instance_or_dict, partial=False, strict=False, trusted_data=No
     # Loop across fields and coerce values
     try:
         data = import_loop(cls, instance_or_dict, field_converter, trusted_data=trusted_data,
-                           partial=partial, strict=strict, init_values=init_values,
-                           context=context, **kwargs)
+                           partial=partial, strict=strict, context=context, **kwargs)
     except ModelConversionError as mce:
         errors = mce.messages
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -43,12 +43,7 @@ natives = { 'intfield': 3,
 def test_to_native():
 
     m = M(input)
-
     assert m.to_native() == m
-
-    _natives = natives.copy()
-    assert m._data.pop('modelfield')._data == _natives.pop('modelfield')
-    assert m._data == _natives
 
 
 def test_to_dict():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from schematics.common import *
 from schematics.models import Model
 from schematics.transforms import ExportConverter
 from schematics.types import *
@@ -21,7 +22,6 @@ class M(BaseModel):
     dtfield = DateTimeType()
     utcfield = UTCDateTimeType()
     modelfield = ModelType(N)
-
 
 input = { 'intfield': 3,
           'stringfield': 'foobar',
@@ -44,6 +44,21 @@ def test_to_native():
 
     m = M(input)
     assert m.to_native() == m
+
+    m = M({'modelfield': {}})
+    result = m.to_native()
+    assert result.intfield is None
+    assert result.modelfield.floatfield is None
+
+    m = M({'modelfield': {}})
+    del m.intfield
+    del m.modelfield.floatfield
+    result = m.to_native()
+    assert 'intfield' not in result
+    assert 'floatfield' not in result.modelfield
+    result = m.to_native(export_level=4)
+    assert result.intfield is None
+    assert result.modelfield.floatfield is None
 
 
 def test_to_dict():
@@ -75,25 +90,24 @@ def test_custom_exporter():
         def to_primitive(self, value, context):
             return dict(x=value.x, y=value.y)
 
-    class M(Model):
+    class X(Model):
         id = UUIDType()
         dt = UTCDateTimeType()
         foo = FooType()
 
-    m = M({ 'id': '54020382-291e-4192-b370-4850493ac5bc',
+    x = X({ 'id': '54020382-291e-4192-b370-4850493ac5bc',
             'dt': '2015-11-26T07:00',
             'foo': {'x': 1, 'y': 2} })
 
-    assert m.to_dict() == {
+    assert x.to_dict() == {
         'id': uuid.UUID('54020382-291e-4192-b370-4850493ac5bc'),
         'dt': datetime.datetime(2015, 11, 26, 7),
         'foo': Foo(1, 2) }
 
     exporter = ExportConverter(PRIMITIVE, [UTCDateTimeType, UUIDType])
 
-    assert m.export(PRIMITIVE, field_converter=exporter) == {
+    assert x.export(PRIMITIVE, field_converter=exporter) == {
         'id': uuid.UUID('54020382-291e-4192-b370-4850493ac5bc'),
         'dt': datetime.datetime(2015, 11, 26, 7),
         'foo': {'x': 1, 'y': 2} }
-
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -69,7 +69,8 @@ def test_custom_exporter():
         def __init__(self, x, y):
             self.x, self.y = x, y
         def __eq__(self, other):
-            return self.x == other.x and self.y == other.y
+            return type(self) == type(other) \
+                     and self.x == other.x and self.y == other.y
 
     class FooType(BaseType):
         def to_native(self, value, context):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -56,7 +56,7 @@ def test_to_native():
     result = m.to_native()
     assert 'intfield' not in result
     assert 'floatfield' not in result.modelfield
-    result = m.to_native(export_level=4)
+    result = m.to_native(export_level=ALL)
     assert result.intfield is None
     assert result.modelfield.floatfield is None
 

--- a/tests/test_export_level.py
+++ b/tests/test_export_level.py
@@ -66,7 +66,7 @@ def test_export_level(models):
     m_level = M._options.export_level
     n_level = N._options.export_level
 
-    output = M(input, init_values=False).to_primitive()
+    output = M(input, init=False).to_primitive()
 
     if m_level == 1 and n_level == 1:
         assert output == {
@@ -155,7 +155,7 @@ def test_export_level_override(models):
     m_level = M._options.export_level
     n_level = N._options.export_level
 
-    m = M(input, init_values=False)
+    m = M(input, init=False)
 
     assert m.to_primitive(export_level=0) == {}
 

--- a/tests/test_export_level.py
+++ b/tests/test_export_level.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from schematics.models import Model
+from schematics.transforms import ExportConverter
+from schematics.types import *
+from schematics.types.compound import *
+from schematics.types.serializable import serializable
+from schematics.undefined import Undefined
+
+
+params = [(None, None), (None, 4), (4, 4), (3, 3), (2, 2), (1, 1)]
+
+@pytest.fixture(params=params)
+def models(request):
+
+    m_level, n_level = request.param
+
+    class N(Model):
+        subfield1 = StringType()
+        subfield2 = StringType()
+        subfield3 = StringType()
+        subfield4 = StringType()
+
+    class M(Model):
+        field0 = StringType(export_level=0)
+        field1 = StringType()
+        field2 = StringType()
+        field3 = StringType()
+        field4 = StringType()
+        field5 = StringType(export_level=2)
+        field6 = StringType(export_level=4)
+        listfield = ListType(StringType())
+        modelfield1 = ModelType(N)
+        modelfield2 = ModelType(N)
+
+    if m_level:
+        M._options.export_level = m_level
+
+    if n_level:
+        N._options.export_level = n_level
+
+    return M, N
+
+
+input = {
+    'field0': 'foo',
+    'field1': 'foo',
+    'field2': '',
+    'field3': None,
+    'field5': None,
+    'listfield': [],
+    'modelfield1': {
+        'subfield1': 'foo',
+        'subfield2': '',
+        'subfield3': None,
+        },
+    'modelfield2': {}
+    }
+
+
+def test_export_level(models):
+
+    M, N = models
+    m_level = M._options.export_level
+    n_level = N._options.export_level
+
+    output = M(input, init_values=False).to_primitive()
+
+    if m_level == 1 and n_level == 1:
+        assert output == {
+            'field1': 'foo',
+            'field2': '',
+            'field6': None,
+            'modelfield1': {
+                'subfield1': 'foo',
+                'subfield2': '',
+                },
+            }
+    elif m_level == 2 and n_level == 2:
+        assert output == {
+            'field1': 'foo',
+            'field2': '',
+            'field6': None,
+            'listfield': [],
+            'modelfield1': {
+                'subfield1': 'foo',
+                'subfield2': '',
+                },
+            'modelfield2': {},
+            }
+    elif m_level == 3 and n_level == 3:
+        assert output == {
+            'field1': 'foo',
+            'field2': '',
+            'field3': None,
+            'field6': None,
+            'listfield': [],
+            'modelfield1': {
+                'subfield1': 'foo',
+                'subfield2': '',
+                'subfield3': None,
+                },
+            'modelfield2': {},
+            }
+    elif m_level == 4 and n_level == 4:
+        assert output == {
+            'field1': 'foo',
+            'field2': '',
+            'field3': None,
+            'field4': None,
+            'field6': None,
+            'listfield': [],
+            'modelfield1': {
+                'subfield1': 'foo',
+                'subfield2': '',
+                'subfield3': None,
+                'subfield4': None,
+                },
+            'modelfield2': {
+                'subfield1': None,
+                'subfield2': None,
+                'subfield3': None,
+                'subfield4': None,
+                },
+            }
+    elif m_level == 3 and n_level == 4:
+        assert output == {
+            'field1': 'foo',
+            'field2': '',
+            'field3': None,
+            'field6': None,
+            'listfield': [],
+            'modelfield1': {
+                'subfield1': 'foo',
+                'subfield2': '',
+                'subfield3': None,
+                'subfield4': None,
+                },
+            'modelfield2': {
+                'subfield1': None,
+                'subfield2': None,
+                'subfield3': None,
+                'subfield4': None,
+                },
+            }
+    else:
+        raise Exception("Assertions missing for testcase m_level={0}, n_level={1}".format(m_level, n_level))
+
+
+def test_export_level_override(models):
+
+    M, N = models
+    m_level = M._options.export_level
+    n_level = N._options.export_level
+
+    m = M(input, init_values=False)
+
+    assert m.to_primitive(export_level=0) == {}
+
+    assert m.to_primitive(export_level=1) == {
+        'field0': 'foo',
+        'field1': 'foo',
+        'field2': '',
+        'modelfield1': {
+            'subfield1': 'foo',
+            'subfield2': '',
+            },
+        }
+
+    assert m.to_primitive(export_level=2) == {
+        'field0': 'foo',
+        'field1': 'foo',
+        'field2': '',
+        'listfield': [],
+        'modelfield1': {
+            'subfield1': 'foo',
+            'subfield2': '',
+            },
+        'modelfield2': {},
+        }
+
+    assert m.to_primitive(export_level=3) == {
+        'field0': 'foo',
+        'field1': 'foo',
+        'field2': '',
+        'field3': None,
+        'field5': None,
+        'listfield': [],
+        'modelfield1': {
+            'subfield1': 'foo',
+            'subfield2': '',
+            'subfield3': None,
+            },
+        'modelfield2': {},
+        }
+
+    assert m.to_primitive(export_level=4) == {
+        'field0': 'foo',
+        'field1': 'foo',
+        'field2': '',
+        'field3': None,
+        'field4': None,
+        'field5': None,
+        'field6': None,
+        'listfield': [],
+        'modelfield1': {
+            'subfield1': 'foo',
+            'subfield2': '',
+            'subfield3': None,
+            'subfield4': None,
+            },
+        'modelfield2': {
+            'subfield1': None,
+            'subfield2': None,
+            'subfield3': None,
+            'subfield4': None,
+            },
+        }
+
+
+def test_custom_converter():
+
+    class M(Model):
+        x = IntType()
+        y = IntType()
+        z = IntType()
+
+    def converter(field, value, context):
+        if field.name == 'z':
+            return Undefined
+        else:
+            return field.export(value, PRIMITIVE, context)
+
+    m = M(dict(x=1, y=None, z=3))
+
+    assert m.export(PRIMITIVE, field_converter=converter, export_level=3) == {'x': 1, 'y': None}
+

--- a/tests/test_export_level.py
+++ b/tests/test_export_level.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from schematics.common import *
 from schematics.models import Model
 from schematics.transforms import ExportConverter
 from schematics.types import *
@@ -10,7 +11,7 @@ from schematics.types.serializable import serializable
 from schematics.undefined import Undefined
 
 
-params = [(None, None), (None, 4), (4, 4), (3, 3), (2, 2), (1, 1)]
+params = [(None, None), (None, ALL), (ALL, ALL), (DEFAULT, DEFAULT), (NOT_NONE, NOT_NONE), (NONEMPTY, NONEMPTY)]
 
 @pytest.fixture(params=params)
 def models(request):
@@ -24,13 +25,13 @@ def models(request):
         subfield4 = StringType()
 
     class M(Model):
-        field0 = StringType(export_level=0)
+        field0 = StringType(export_level=DROP)
         field1 = StringType()
         field2 = StringType()
         field3 = StringType()
         field4 = StringType()
-        field5 = StringType(export_level=2)
-        field6 = StringType(export_level=4)
+        field5 = StringType(export_level=NOT_NONE)
+        field6 = StringType(export_level=ALL)
         listfield = ListType(StringType())
         modelfield1 = ModelType(N)
         modelfield2 = ModelType(N)
@@ -68,7 +69,7 @@ def test_export_level(models):
 
     output = M(input, init=False).to_primitive()
 
-    if m_level == 1 and n_level == 1:
+    if m_level == NONEMPTY and n_level == NONEMPTY:
         assert output == {
             'field1': 'foo',
             'field2': '',
@@ -78,7 +79,7 @@ def test_export_level(models):
                 'subfield2': '',
                 },
             }
-    elif m_level == 2 and n_level == 2:
+    elif m_level == NOT_NONE and n_level == NOT_NONE:
         assert output == {
             'field1': 'foo',
             'field2': '',
@@ -90,7 +91,7 @@ def test_export_level(models):
                 },
             'modelfield2': {},
             }
-    elif m_level == 3 and n_level == 3:
+    elif m_level == DEFAULT and n_level == DEFAULT:
         assert output == {
             'field1': 'foo',
             'field2': '',
@@ -104,7 +105,7 @@ def test_export_level(models):
                 },
             'modelfield2': {},
             }
-    elif m_level == 4 and n_level == 4:
+    elif m_level == ALL and n_level == ALL:
         assert output == {
             'field1': 'foo',
             'field2': '',
@@ -125,7 +126,7 @@ def test_export_level(models):
                 'subfield4': None,
                 },
             }
-    elif m_level == 3 and n_level == 4:
+    elif m_level == DEFAULT and n_level == ALL:
         assert output == {
             'field1': 'foo',
             'field2': '',
@@ -157,9 +158,9 @@ def test_export_level_override(models):
 
     m = M(input, init=False)
 
-    assert m.to_primitive(export_level=0) == {}
+    assert m.to_primitive(export_level=DROP) == {}
 
-    assert m.to_primitive(export_level=1) == {
+    assert m.to_primitive(export_level=NONEMPTY) == {
         'field0': 'foo',
         'field1': 'foo',
         'field2': '',
@@ -169,7 +170,7 @@ def test_export_level_override(models):
             },
         }
 
-    assert m.to_primitive(export_level=2) == {
+    assert m.to_primitive(export_level=NOT_NONE) == {
         'field0': 'foo',
         'field1': 'foo',
         'field2': '',
@@ -181,7 +182,7 @@ def test_export_level_override(models):
         'modelfield2': {},
         }
 
-    assert m.to_primitive(export_level=3) == {
+    assert m.to_primitive(export_level=DEFAULT) == {
         'field0': 'foo',
         'field1': 'foo',
         'field2': '',
@@ -196,7 +197,7 @@ def test_export_level_override(models):
         'modelfield2': {},
         }
 
-    assert m.to_primitive(export_level=4) == {
+    assert m.to_primitive(export_level=ALL) == {
         'field0': 'foo',
         'field1': 'foo',
         'field2': '',
@@ -235,5 +236,5 @@ def test_custom_converter():
 
     m = M(dict(x=1, y=None, z=3))
 
-    assert m.export(PRIMITIVE, field_converter=converter, export_level=3) == {'x': 1, 'y': None}
+    assert m.export(PRIMITIVE, field_converter=converter, export_level=DEFAULT) == {'x': 1, 'y': None}
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from schematics.models import Model
+from schematics.types import BaseType, IntType, StringType
+from schematics.types.compound import ListType, DictType, ModelType
+from schematics.exceptions import ModelConversionError, ModelValidationError
+from schematics.undefined import Undefined
+
+
+class M(Model):
+    a, b, c, d = IntType(), IntType(), IntType(), IntType()
+
+
+def test_import_data():
+
+    m = M({
+        'a': 1,
+        'b': None,
+        'c': 3
+    })
+
+    m.import_data({
+        'a': None,
+        'b': 2
+    })
+    assert m._data == {'a': None, 'b': 2, 'c': 3, 'd': None}
+
+    m = M({
+        'a': 1,
+        'b': None,
+        'c': 3
+    }, init=False)
+
+    m.import_data({
+        'a': None,
+        'b': 2
+    })
+    assert m._data == {'a': None, 'b': 2, 'c': 3, 'd': Undefined}
+

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -106,3 +106,13 @@ def test_setdefault():
     assert result == b.z == 9
     assert B.z is None
 
+
+def test_constant():
+
+    C = Constant('C', 99)
+    assert C == 99
+    assert C.name == 'C'
+
+    with pytest.raises(ValueError):
+        C = Constant('C', 'foo')
+

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from schematics.common import *
+from schematics.models import Model
+from schematics.transforms import ExportConverter
+from schematics.types import *
+from schematics.types.compound import *
+from schematics.types.serializable import serializable
+from schematics.undefined import *
+from schematics.util import *
+
+
+def test_undefined():
+
+    assert str(Undefined) == 'Undefined'
+    assert repr(Undefined) == 'Undefined'
+
+    assert Undefined == Undefined
+    assert not Undefined != Undefined
+
+    assert bool(Undefined) is False
+
+    assert Undefined not in (None, True, False, 0, 1)
+
+    with pytest.raises(TypeError):
+        int(Undefined)
+
+    with pytest.raises(TypeError):
+        Undefined < 0
+    with pytest.raises(TypeError):
+        Undefined > 0
+    with pytest.raises(TypeError):
+        Undefined >= 0
+    with pytest.raises(TypeError):
+        Undefined >= 0
+
+    with pytest.raises(TypeError):
+        Undefined()
+
+    with pytest.raises(TypeError):
+        Undefined.x = 1
+    with pytest.raises(AttributeError):
+        Undefined.x
+
+    assert UndefinedType() is Undefined
+
+    with pytest.raises(TypeError):
+        class DerivativeType(UndefinedType):
+            pass
+        DerivativeType()
+
+
+def test_setdefault():
+
+    class A(object):
+        y = 2
+        z = None
+
+    class B(A):
+        pass
+
+    b = B()
+    result = setdefault(b, 'i', 9)
+    assert result == b.i == 9
+    with pytest.raises(AttributeError):
+        B.i
+
+    b = B()
+    b.i = 1
+    result = setdefault(b, 'i', 9)
+    assert result == b.i == 1
+
+    b = B()
+    b.i = None
+    result = setdefault(b, 'i', 9)
+    assert result is b.i is None
+
+    b = B()
+    b.i = None
+    result = setdefault(b, 'i', 9, overwrite_none=True)
+    assert result == b.i == 9
+    assert B.y == 2
+
+    b = B()
+    result = setdefault(b, 'y', 9)
+    assert result == b.y == 9
+    assert B.y == 2
+
+    b = B()
+    result = setdefault(b, 'y', 9, overwrite_none=True)
+    assert result == b.y == 9
+    assert B.y == 2
+
+    b = B()
+    result = setdefault(b, 'y', 9, search_mro=True)
+    assert result == b.y == 2
+
+    b = B()
+    result = setdefault(b, 'z', 9, search_mro=True)
+    assert result is b.z is None
+
+    b = B()
+    result = setdefault(b, 'z', 9, search_mro=True, overwrite_none=True)
+    assert result == b.z == 9
+    assert B.z is None
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from schematics.models import Model
+from schematics.models import Model, ModelOptions
 from schematics.transforms import whitelist, blacklist
-from schematics.models import ModelOptions
+from schematics.undefined import Undefined
 
 from schematics.types.base import StringType, IntType
 from schematics.types.compound import ModelType
-from schematics.exceptions import ValidationError, ConversionError, ModelConversionError
+from schematics.exceptions import ValidationError, ConversionError, ModelConversionError, MissingValueError
 
 from six import PY3
 
@@ -476,62 +476,75 @@ def test_nested_model_import_data_with_mappings():
     assert root.nxt_level.nested_attr == 'nested value'
 
 
-def test_fielddescriptor_connectedness():
-    class TestModel(Model):
-        field1 = StringType()
-        field2 = StringType()
-
-    inst = TestModel()
-    inst._data = {}
-    with pytest.raises(AttributeError):
-        inst.field1
+class SimpleModel(Model):
+    field1 = StringType()
+    field2 = StringType()
 
 
 def test_keys():
-    class TestModel(Model):
-        field1 = StringType()
-        field2 = StringType()
-
-    inst = TestModel({'field1': 'foo', 'field2': 'bar'})
+    inst = SimpleModel({'field1': 'foo',
+                        'field2': 'bar'})
 
     assert inst.keys() == ['field1', 'field2']
+    del inst.field2
+    assert inst.keys() == ['field1']
 
 
 def test_values():
-    class TestModel(Model):
-        field1 = StringType()
-        field2 = StringType()
-
-    inst = TestModel({'field1': 'foo', 'field2': 'bar'})
+    inst = SimpleModel({'field1': 'foo',
+                        'field2': 'bar'})
 
     assert inst.values() == ['foo', 'bar']
+    del inst.field2
+    assert inst.values() == ['foo']
 
 
 def test_items():
-    class TestModel(Model):
-        field1 = StringType()
-        field2 = StringType()
-
-    inst = TestModel({'field1': 'foo', 'field2': 'bar'})
+    inst = SimpleModel({'field1': 'foo',
+                        'field2': 'bar'})
 
     assert inst.items() == [('field1', 'foo'), ('field2', 'bar')]
+    del inst.field2
+    assert inst.items() == [('field1', 'foo')]
+
+
+def test_iter():
+    inst = SimpleModel({'field1': 'foo',
+                        'field2': 'bar'})
+
+    assert [x for x in inst] == ['field1', 'field2']
+    del inst.field2
+    assert [x for x in inst] == ['field1']
+
+
+def test_membership():
+    inst = SimpleModel({'field1': 'foo',
+                        'field2': 'bar'})
+
+    assert 'field1' in inst and 'field2' in inst
+    del inst.field2
+    assert 'field1' in inst and 'field2' not in inst
 
 
 def test_get():
-    class TestModel(Model):
-        field1 = StringType()
 
-    inst = TestModel({'field1': 'foo'})
+    inst = SimpleModel({'field1': 'foo'})
     assert inst.get('field1') == 'foo'
     assert inst.get('foo') is None
     assert inst.get('foo', 'bar') == 'bar'
 
 
-def test_setitem():
-    class TestModel(Model):
-        field1 = StringType()
+def test_getitem():
 
-    inst = TestModel()
+    inst = SimpleModel({'field1': 'foo'})
+    assert inst['field1'] == 'foo'
+    assert inst['field2'] is None
+    with pytest.raises(KeyError):
+        inst['foo']
+
+
+def test_setitem():
+    inst = SimpleModel()
 
     with pytest.raises(KeyError):
         inst['foo'] = 1
@@ -541,33 +554,26 @@ def test_setitem():
 
 
 def test_delitem():
-    class TestModel(Model):
-        field1 = StringType()
-
-    inst = TestModel({'field1': 'foo'})
+    inst = SimpleModel({'field1': 'foo'})
 
     with pytest.raises(KeyError):
         del inst['foo']
 
     del inst['field1']
-    assert inst.field1 is None
+    with pytest.raises(AttributeError):
+        inst.field1
 
 
 def test_eq():
-    class TestModel(Model):
-        field1 = StringType()
-
-    inst = TestModel({'field1': 'foo'})
+    inst = SimpleModel({'field1': 'foo'})
     assert inst != 'foo'
 
 
 def test_repr():
-    class TestModel(Model):
-        field1 = StringType()
-
-    inst = TestModel({'field1': 'foo'})
-    assert repr(inst) == '<TestModel: TestModel object>'
+    inst = SimpleModel({'field1': 'foo'})
+    assert repr(inst) == '<SimpleModel: SimpleModel object>'
 
     if not PY3: #todo: make this work for PY3
         inst.__class__.__name__ = '\x80'
         assert repr(inst) == '<[Bad Unicode class name]: [Bad Unicode data]>'
+

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+from schematics.common import *
 from schematics.models import Model
 from schematics.types import StringType, LongType, IntType, MD5Type
 from schematics.types.compound import ModelType, DictType, ListType
@@ -485,7 +486,7 @@ def test_serialize_none_fields_if_export_loop_says_so():
 
     q = TestModel({'inst_id': 1})
 
-    d = export_loop(TestModel, q, lambda field, value, context: None, export_level=3)
+    d = export_loop(TestModel, q, lambda field, value, context: None, export_level=DEFAULT)
     assert d == {'inst_id': None}
 
 
@@ -495,7 +496,7 @@ def test_serialize_print_none_always_gets_you_something():
 
     q = TestModel()
 
-    d = export_loop(TestModel, q, lambda field, value, context: None, export_level=3)
+    d = export_loop(TestModel, q, lambda field, value, context: None, export_level=DEFAULT)
     assert d == {}
 
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -485,7 +485,7 @@ def test_serialize_none_fields_if_export_loop_says_so():
 
     q = TestModel({'inst_id': 1})
 
-    d = export_loop(TestModel, q, lambda field, value, context: None, print_none=True)
+    d = export_loop(TestModel, q, lambda field, value, context: None, export_level=3)
     assert d == {'inst_id': None}
 
 
@@ -495,7 +495,7 @@ def test_serialize_print_none_always_gets_you_something():
 
     q = TestModel()
 
-    d = export_loop(TestModel, q, lambda field, value, context: None, print_none=True)
+    d = export_loop(TestModel, q, lambda field, value, context: None, export_level=3)
     assert d == {}
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -365,6 +365,21 @@ def test_validate_convert():
     assert IntType().validate("foo", convert=False) == "foo"
 
 
+def test_validate_apply_defaults():
+
+    class M(Model):
+        field1 = StringType()
+        field2 = StringType(default='foo')
+
+    m = M({'field1': None}, init=False)
+
+    m.validate()
+    assert m.to_primitive() == {'field1': None}
+
+    m.validate(apply_defaults=True)
+    assert m.to_primitive() == {'field1': None, 'field2': 'foo'}
+
+
 def test_clean_validation_messages():
     error = BaseError(["A"])
     assert error.messages == ["A"]


### PR DESCRIPTION
### Basics

As before, objects are populated by default.

```python
class M(Model):
    intfield = IntType()
    stringfield = StringType()
    defaultfield = StringType(default='foo')
```

```python
>>> m = M()
>>> m.to_primitive()
{'intfield': None, 'stringfield': None, 'defaultfield': 'foo'}
```

The `del` statement, which [used to be completely broken](https://github.com/schematics/schematics/pull/349), can now be used to clear an individual value.

```python
>>> del m.intfield
>>> m.to_primitive()
{'defaultfield': 'foo', 'stringfield': None}
```

Internally, we have the `Undefined` singleton as a placeholder to indicate the absence of a value.

```python
>>> m._data
{'intfield': Undefined, 'stringfield': None, 'defaultfield': 'foo'}
>>> 'intfield' in m
False
```

Attempting to access a nonexistent value through an attribute will raise an error that is a subclass of `AttributeError`.

There are two new parameters recognized by `import_loop`:

  * `init_values`: What to do with missing values

    * `True`: initialize to `None`
    * `False`: leave as `Undefined` (default)

  * `apply_defaults`: What to do with fields' defaults

    * `True`: honor them
    * `False`: ignore them (default)

Normally, `Model.__init__()` overrides both of these. Its arguments include `init=True`, which is just a shortcut for setting both `init_values` and `apply_defaults` at once when creating a new instance.

So, to avoid pre-populating the model, one can specify `init=False`:

```python
>>> m = M({'intfield': 1}, init=False)
>>> m.to_primitive()
{'intfield': 1}
>>> m._data
{'intfield': 1, 'stringfield': Undefined, 'defaultfield': Undefined}
```

Obviously, `init_values` and `apply_defaults` can also be set independently.

### Field defaults

Presently, Schematics turns `None` values into the fields' respective defaults on every import and even during validation, which IMO is plainly a bug.

As of this PR, these issues are fixed by virtue of

  * substituting defaults for *missing values only*
    (i.e., `None` in the input is now considered an explicit value that will *not* be replaced)
  * having `apply_defaults` turned off by default (as it's mainly useful during `__init__` only).

### Controlling what to export

There's a new option `export_level` that can appear in field definitions and model options. It supersedes `serialize_when_none`.

export_level | Undefined | None | Empty containers | Other values
-------------| --------- | ---- | ---------------- | ------------
ALL          | YES       | YES  | YES              | YES
DEFAULT      | NO        | YES  | YES              | YES
NOT_NONE     | NO        | NO   | YES              | YES
NONEMPTY     | NO        | NO   | NO               | YES
DROP         | NO        | NO   | NO               | NO

The default level is inherited from the base class options.

`serialize_when_none` remains as a (deprecated) synonym for `export_level`: `True => DEFAULT`, `False => NONEMPTY`.

`export_level` can also be passed as an argument to export methods, in which case it will override any field- and model-level settings. In this capacity, it replaces `print_none`, which is removed.

Missing values appear as `None` when exported.

```python
>>> m.to_primitive()
{'intfield': 1}
>>> m.to_primitive(export_level=ALL)
{'intfield': 1, 'stringfield': None, 'defaultfield': None}
```

### The model interface

`keys()`, `values()`, `items()`, and `__len__()` exclude unset fields.

By contrast, `atoms()` exposes the `Undefined` objects directly.

~~The subscription syntax also returns any `Undefined`s.~~

### Compatibility

Existing tests continue to pass unchanged except for

  * one test looking at the `del` statement, which only recently got fixed anyway
  * two tests that were passing the now-defunct `print_none` parameter to `export_loop`.

Breaking changes are mainly about fixing weird behaviors, most notably the habit of default values to reappear at every turn.
