### PR TITLE
Validation refactoring + exception redesign

### DIFF
--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -1,59 +1,162 @@
+from collections import Iterable
+
 from six import iteritems
 
-class BaseError(Exception):
+from .util import listify
 
-    def __init__(self, messages):
-        if not isinstance(messages, (list, tuple, dict)):
-            messages = [messages]
+try:
+    basestring #PY2
+    bytes = str
+except NameError:
+    basestring = str #PY3
+    unicode = str
 
-        clean_messages = self.clean_messages(messages)
 
-        Exception.__init__(self, clean_messages)
-        self.messages = clean_messages
+class ErrorMessage(object):
 
-    def clean_messages(self, messages):
-        if isinstance(messages, dict):
-            clean_messages = {}
-            for key, value in iteritems(messages):
-                if isinstance(value, ValidationError):
-                    value = value.messages
-                clean_messages[key] = value
+    def __init__(self, summary, info=None):
+        self.type = None
+        self.summary = summary
+        self.info = info
+
+    def __str__(self):
+        return self.summary
+
+    def __repr__(self):
+        return '{0}("{1}", info={2})'.format(type(self).__name__, self.summary, self.info_repr)
+
+    @property
+    def info_repr(self):
+        if self.info is None:
+            return 'None'
+        elif isinstance(self.info, int):
+            return self.info
+        elif isinstance(self.info, basestring):
+            return '"{0}"'.format(self.info)
         else:
-            clean_messages = []
-            for message in messages:
-                if isinstance(message, ValidationError):
-                    message = message.messages
-                clean_messages.append(message)
+            return "<'{0}' object>".format(type(self.info).__name__)
 
-        return clean_messages
+    def __eq__(self, other):
+        if isinstance(other, ErrorMessage):
+            return self.__dict__ == other.__dict__
+        elif isinstance(other, basestring):
+            return self.summary == other
+        else:
+            return False
 
 
-class ConversionError(BaseError, TypeError):
+class BaseError(Exception):
+    pass
 
+
+class FieldError(BaseError):
+
+    type = None
+
+    def __init__(self, *args, **kwargs):
+
+        if type(self) is FieldError:
+            raise NotImplementedError("Please raise either ConversionError or ValidationError.")
+        if len(args) == 0:
+            raise TypeError("Please provide at least one error or error message.")
+        if kwargs:
+            items = [ErrorMessage(*args, **kwargs)]
+        elif len(args) == 1:
+            items = listify(args[0])
+        else:
+            items = args
+        self.messages = []
+        for item in items:
+            if isinstance(item, basestring):
+                self.messages.append(ErrorMessage(item))
+            elif isinstance(item, tuple):
+                self.messages.append(ErrorMessage(*item))
+            elif isinstance(item, ErrorMessage):
+                self.messages.append(item)
+            elif isinstance(item, self.__class__):
+                self.messages.extend(item.messages)
+            else:
+                raise TypeError("'{0}()' object is neither a {1} nor an error message."\
+                                .format(type(item).__name__, type(self).__name__))
+        for message in self.messages:
+            message.type = self.type or type(self)
+
+        Exception.__init__(self, self.messages)
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return other.messages == self.messages
+        elif type(other) is list:
+            return other == self.messages
+        return False
+
+    def __contains__(self, value):
+        return value in self.messages
+
+    def __getitem__(self, key):
+        return self.messages[key]
+
+    def __iter__(self):
+        return iter(self.messages)
+
+    def __len__(self):
+        return len(self.messages)
+
+    def __repr__(self):
+        if len(self.messages) == 1:
+            msg = self.messages[0]
+            msg_repr = '"{0}", info={1}'.format(msg.summary, msg.info_repr)
+        else:
+            msg_repr = str.join(', ',
+                                ('("{0}", {1})'.format(msg.summary, msg.info_repr)
+                                 for msg in self.messages))
+        return '{0}({1})'.format(type(self).__name__, msg_repr)
+
+    __str__ = __repr__
+
+    def pop(self, *args):
+        return self.messages.pop(*args)
+
+
+class ConversionError(FieldError, TypeError):
     """ Exception raised when data cannot be converted to the correct python type """
     pass
 
 
-class ModelConversionError(ConversionError):
-    def __init__(self, messages, partial_data=None):
-        super(ModelConversionError, self).__init__(messages)
-        self.partial_data = partial_data
-
-
-class ValidationError(BaseError, ValueError):
-
+class ValidationError(FieldError, ValueError):
     """Exception raised when invalid data is encountered."""
     pass
 
 
-class ModelValidationError(ValidationError):
-    pass
-
-
-class StopValidation(ValidationError):
-
+class StopValidationError(ValidationError):
     """Exception raised when no more validation need occur."""
-    pass
+    type = ValidationError
+
+StopValidation = StopValidationError
+
+
+class CompoundError(BaseError):
+
+    def __init__(self, errors):
+        if not isinstance(errors, dict):
+            raise TypeError("Compound errors must be reported as a dictionary.")
+        self.messages = {}
+        for key, value in errors.items():
+            if isinstance(value, CompoundError):
+                self.messages[key] = value.messages
+            else:
+                self.messages[key] = value
+        Exception.__init__(self, self.messages)
+
+
+class DataError(CompoundError):
+
+    def __init__(self, messages, partial_data=None):
+        super(DataError, self).__init__(messages)
+        self.partial_data = partial_data
+
+ModelConversionError = DataError
+ModelValidationError = DataError
 
 
 class MockCreationError(ValueError):

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -56,11 +56,7 @@ class FieldDescriptor(object):
         Sets the field's value.
         """
         field = instance._fields[self.name]
-        if all((
-                value is not None,
-                not isinstance(value, Model),
-                isinstance(field, ModelType))):
-            value = field.model_class(value)
+        value = field.pre_setattr(value)
         instance._data[self.name] = value
 
     def __delete__(self, instance):
@@ -433,5 +429,4 @@ class Model(object):
 
 from .transforms import atoms, flatten, expand
 from .transforms import convert, to_native, to_dict, to_primitive, export_loop
-from .types.compound import ModelType
 from .validate import validate, prepare_validator

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -235,6 +235,9 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
             default = default()
         return default
 
+    def pre_setattr(self, value):
+        return value
+
     def convert(self, value, context=None):
         return self.to_native(value, context)
 

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -16,11 +16,10 @@ import six
 from six import iteritems
 
 from ..common import *
-from ..exceptions import (
-    StopValidation, ValidationError, ConversionError, MockCreationError
-)
+from ..datastructures import Context
+from ..exceptions import ConversionError, ValidationError, StopValidationError
 from ..undefined import Undefined
-from ..validate import prepare_validator
+from ..validate import prepare_validator, get_validation_context
 
 try:
     from string import ascii_letters # PY3
@@ -168,6 +167,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
                  export_level=None, serialize_when_none=None,
                  messages=None, **kwargs):
         super(BaseType, self).__init__()
+
         self.required = required
         self._default = default
         self.serialized_name = serialized_name
@@ -255,42 +255,40 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         """
         return value
 
-    def validate(self, value, convert=True, context=None):
+    def validate(self, value, context=None):
         """
         Validate the field and return a converted value or raise a
         ``ValidationError`` with a list of errors raised by the validation
         chain. Stop the validation process from continuing through the
-        validators by raising ``StopValidation`` instead of ``ValidationError``.
+        validators by raising ``StopValidationError`` instead of ``ValidationError``.
 
         """
-        self.check_required(value, context)
-        if value in (None, Undefined):
-            return value
+        context = context or get_validation_context()
 
-        if convert:
+        if context.convert:
             value = self.convert(value, context)
+        elif self.is_compound:
+            self.convert(value, context)
 
         errors = []
-
         for validator in self.validators:
             try:
-                validator(value, context=context)
+                validator(value, context)
             except ValidationError as exc:
-                errors.extend(exc.messages)
-                if isinstance(exc, StopValidation):
+                errors.append(exc)
+                if isinstance(exc, StopValidationError):
                     break
-
         if errors:
             raise ValidationError(errors)
 
         return value
 
-    def check_required(self, value, context=None):
+    def check_required(self, value, context):
         if self.required and value in (None, Undefined):
             if self.name is None or context and not context.partial:
-                raise ValidationError(self.messages['required'])
+                raise ConversionError(self.messages['required'])
 
-    def validate_choices(self, value, context=None):
+    def validate_choices(self, value, context):
         if self.choices is not None:
             if value not in self.choices:
                 raise ValidationError(self.messages['choices']
@@ -440,14 +438,14 @@ class URLType(StringType):
 
     def validate_url(self, value, context=None):
         if not URLType.URL_REGEX.match(value):
-            raise StopValidation(self.messages['invalid_url'])
+            raise StopValidationError(self.messages['invalid_url'])
         if self.verify_exists:
             from six.moves import urllib
             try:
                 request = urllib.Request(value)
                 urllib.urlopen(request)
             except Exception:
-                raise StopValidation(self.messages['not_found'])
+                raise StopValidationError(self.messages['not_found'])
 
 
 class EmailType(StringType):
@@ -476,7 +474,7 @@ class EmailType(StringType):
 
     def validate_email(self, value, context=None):
         if not EmailType.EMAIL_REGEX.match(value):
-            raise StopValidation(self.messages['email'])
+            raise StopValidationError(self.messages['email'])
 
 
 class NumberType(BaseType):

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -129,20 +129,18 @@ class ModelType(MultiType):
         model_instance.validate(context=context)
 
     def convert(self, value, context):
-        # We have already checked if the field is required. If it is None it
-        # should continue being None
-        if value is None:
-            return None
-        if isinstance(value, self.model_class):
-            return value
 
-        if not isinstance(value, dict):
+        if isinstance(value, self.model_class):
+            model_class = type(value)
+        elif not isinstance(value, dict):
             raise ConversionError(
                 u'Please use a mapping for this field or {0} instance instead of {1}.'.format(
                     self.model_class.__name__,
                     type(value).__name__))
+        else:
+            model_class = self.model_class
 
-        return self.model_class(value, context=context)
+        return model_class(value, context=context)
 
     def export(self, model_instance, format, context):
         return model_instance.export(format=format, context=context)

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -7,9 +7,7 @@ import itertools
 import functools
 
 from ..common import *
-from ..exceptions import (ValidationError, ConversionError,
-                          ModelValidationError, StopValidation,
-                          MockCreationError)
+from ..exceptions import *
 from ..models import Model, ModelMeta
 from ..undefined import Undefined
 from .base import BaseType, get_value_in
@@ -33,33 +31,6 @@ class MultiType(BaseType):
         if hasattr(self, 'field'):
             self.field._setup(None, owner_model)
         super(MultiType, self)._setup(field_name, owner_model)
-
-    def validate(self, value, convert=True, context=None):
-        """Report dictionary of errors with lists of errors as values of each
-        key. Used by ModelType and ListType.
-
-        """
-        self.check_required(value, context)
-        if value in (None, Undefined):
-            return value
-
-        if convert:
-            value = self.convert(value, context)
-
-        errors = {}
-
-        for validator in self.validators:
-            try:
-                validator(value, context=context)
-            except ModelValidationError as exc:
-                errors.update(exc.messages)
-                if isinstance(exc, StopValidation):
-                    break
-
-        if errors:
-            raise ValidationError(errors)
-
-        return value
 
     def convert(self, value, context):
         raise NotImplementedError
@@ -132,22 +103,18 @@ class ModelType(MultiType):
             value = self.model_class(value)
         return value
 
-    def validate_model(self, model_instance, context=None):
-        model_instance.validate(context=context)
-
     def convert(self, value, context):
 
         if isinstance(value, self.model_class):
             model_class = type(value)
-        elif not isinstance(value, dict):
+        elif isinstance(value, dict):
+            model_class = self.model_class
+        else:
             raise ConversionError(
                 u'Please use a mapping for this field or {0} instance instead of {1}.'.format(
                     self.model_class.__name__,
                     type(value).__name__))
-        else:
-            model_class = self.model_class
-
-        return model_class(value, context=context)
+        return model_class._convert(value, context=context)
 
     def export(self, model_instance, format, context):
         return model_instance.export(format=format, context=context)
@@ -187,7 +154,7 @@ class ListType(MultiType):
         return [self.field._mock(context) for _ in xrange(random_length)]
 
     def _force_list(self, value):
-        if value is None or value == EMPTY_LIST:
+        if value == EMPTY_LIST:
             return []
 
         try:
@@ -202,10 +169,19 @@ class ListType(MultiType):
             return [value]
 
     def convert(self, value, context):
-        items = self._force_list(value)
-        return [self.field.convert(item, context) for item in items]
+        value = self._force_list(value)
+        data = []
+        errors = {}
+        for index, item in enumerate(value):
+            try:
+                data.append(context.field_converter(self.field, item, context))
+            except BaseError as exc:
+                errors[index] = exc
+        if errors:
+            raise CompoundError(errors)
+        return data
 
-    def check_length(self, value, context=None):
+    def check_length(self, value, context):
         list_length = len(value) if value else 0
 
         if self.min_size is not None and list_length < self.min_size:
@@ -221,17 +197,6 @@ class ListType(MultiType):
                 False: u'Please provide no more than %d items.',
             }[self.max_size == 1]) % self.max_size
             raise ValidationError(message)
-
-    def validate_items(self, items, context=None):
-        errors = {}
-        for index, value in enumerate(items):
-            try:
-                self.field.validate(value, context)
-            except ValidationError as exc:
-                errors[index] = exc
-
-        if errors:
-            raise ValidationError(errors)
 
     def export(self, list_instance, format, context):
         """Loops over each item in the model and applies either the field
@@ -267,9 +232,7 @@ class DictType(MultiType):
         self.coerce_key = coerce_key or unicode
         self.field = field
 
-        validators = [self.validate_items] + kwargs.pop("validators", [])
-
-        super(DictType, self).__init__(validators=validators, **kwargs)
+        super(DictType, self).__init__(**kwargs)
 
     @property
     def model_class(self):
@@ -278,23 +241,19 @@ class DictType(MultiType):
     def convert(self, value, context, safe=False):
         if value == EMPTY_DICT:
             value = {}
-        value = value or {}
         if not isinstance(value, dict):
             raise ConversionError(u'Only dictionaries may be used in a DictType')
 
-        return dict((self.coerce_key(k), self.field.convert(v, context))
-                    for k, v in iteritems(value))
-
-    def validate_items(self, items, context=None):
+        data = {}
         errors = {}
-        for key, value in iteritems(items):
+        for k, v in iteritems(value):
             try:
-                self.field.validate(value, context)
-            except ValidationError as exc:
-                errors[key] = exc
-
+                data[self.coerce_key(k)] = context.field_converter(self.field, v, context)
+            except BaseError as exc:
+                errors[k] = exc
         if errors:
-            raise ValidationError(errors)
+            raise CompoundError(errors)
+        return data
 
     def export(self, dict_instance, format, context):
         """Loops over each item in the model and applies either the field
@@ -353,9 +312,6 @@ class PolyModelType(MultiType):
                 resolved_classes.append(m)
         self.model_classes = tuple(resolved_classes)
         super(PolyModelType, self)._setup(field_name, owner_model)
-
-    def validate_model(self, model_instance, context=None):
-        model_instance.validate(context=context)
 
     def is_allowed_model(self, model_instance):
         if self.allow_subclasses:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -10,6 +10,7 @@ from ..common import *
 from ..exceptions import (ValidationError, ConversionError,
                           ModelValidationError, StopValidation,
                           MockCreationError)
+from ..models import Model, ModelMeta
 from ..undefined import Undefined
 from .base import BaseType, get_value_in
 
@@ -124,6 +125,12 @@ class ModelType(MultiType):
             else:
                 raise Exception("ModelType: Unable to resolve model '{}'.".format(self.model_name))
         super(ModelType, self)._setup(field_name, owner_model)
+
+    def pre_setattr(self, value):
+        if value is not None \
+          and not isinstance(value, Model):
+            value = self.model_class(value)
+        return value
 
     def validate_model(self, model_instance, context=None):
         model_instance.validate(context=context)
@@ -417,5 +424,3 @@ class PolyModelType(MultiType):
 
         return model_instance.export(format=format, context=context)
 
-
-from ..models import ModelMeta

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division
 
+import collections
+
 try:
     basestring #PY2
     bytes = str
@@ -36,4 +38,16 @@ class Constant(int):
         return self.name
 
     __str__ = __repr__
+
+
+def listify(value):
+    if isinstance(value, list):
+        return value
+    elif value is None:
+        return []
+    elif isinstance(value, collections.Sequence) \
+      and not isinstance(value, basestring):
+        return list(value)
+    else:
+        return [value]
 

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -1,7 +1,8 @@
 import functools
 import inspect
 
-from .exceptions import BaseError, ValidationError, ModelConversionError
+from .datastructures import Context
+from .exceptions import FieldError, DataError
 from .undefined import Undefined
 
 
@@ -37,36 +38,27 @@ def validate(cls, instance_or_dict, trusted_data=None, partial=False, strict=Fal
     """
     from .transforms import import_loop
 
-    data = {}
+    context = context or get_validation_context(partial=partial, strict=strict, convert=convert)
+
     errors = {}
-
-    # Function for validating an individual field
-    def field_converter(field, value, context):
-        return field.validate(value, convert, context)
-
-    # Loop across fields and coerce values
     try:
-        data = import_loop(cls, instance_or_dict, field_converter, trusted_data=trusted_data,
-                           partial=partial, strict=strict, context=context, **kwargs)
-    except ModelConversionError as mce:
-        errors = mce.messages
+        data = import_loop(cls, instance_or_dict, trusted_data=trusted_data,
+                           context=context, **kwargs)
+    except DataError as exc:
+        errors = exc.messages
+        data = exc.partial_data
 
-    # Check if unknown fields are present
-    if strict:
-        rogue_field_errors = _check_for_unknown_fields(cls, data)
-        errors.update(rogue_field_errors)
+    partial_data = dict(((key, value) for key, value in data.items() if value is not Undefined))
 
-    # Model level validation
-    instance_errors = _validate_model(cls, data, context)
-    errors.update(instance_errors)
+    errors.update(_validate_model(cls, data, partial_data, context))
 
     if errors:
-        raise ValidationError(errors)
+        raise DataError(errors, partial_data)
 
     return data
 
 
-def _validate_model(cls, data, context):
+def _validate_model(cls, data, partial_data, context):
     """
     Validate data using model level methods.
 
@@ -82,42 +74,34 @@ def _validate_model(cls, data, context):
     errors = {}
     invalid_fields = []
     for field_name, field in cls._fields.iteritems():
-        if field_name in cls._validator_functions and field_name in data:
+        if field_name in cls._validator_functions and field_name in partial_data:
             value = data[field_name]
             try:
-                cls._validator_functions[field_name](cls, data, value, context)
-            except BaseError as exc:
+                cls._validator_functions[field_name](cls, partial_data, value, context)
+            except FieldError as exc:
                 field = cls._fields[field_name]
                 serialized_field_name = field.serialized_name or field_name
                 errors[serialized_field_name] = exc.messages
                 invalid_fields.append(field_name)
 
     for field_name in invalid_fields:
-        data.pop(field_name, None)  # get rid of the invalid field
+        data.pop(field_name)
+        partial_data.pop(field_name)
 
     return errors
 
 
-def _check_for_unknown_fields(cls, data):
-    """
-    Checks for keys in a dictionary that don't exist as fields on a model.
-
-    :param cls:
-        The ``Model`` class to validate ``data`` against.
-
-    :param data:
-        A dict with keys to validate.
-
-    :returns:
-        Errors of the fields that were not present in ``cls``.
-    """
-    errors = {}
-    fields = set(getattr(cls, '_initial', {})) | set(data)
-    rogues_found = fields - set(cls._fields)
-    if rogues_found:
-        for field_name in rogues_found:
-            errors[field_name] = [u'%s is an illegal field.' % field_name]
-    return errors
+def get_validation_context(**options):
+    from .transforms import validation_converter
+    validation_options = {
+        'field_converter': validation_converter,
+        'partial': False,
+        'strict': False,
+        'convert': True,
+        'validate': True
+    }
+    validation_options.update(options)
+    return Context(**validation_options)
 
 
 def prepare_validator(func, argcount):

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -5,7 +5,7 @@ from schematics.models import Model
 from schematics.types.base import StringType
 from schematics.types.compound import ListType, ModelType
 from schematics.types.serializable import serializable
-from schematics.exceptions import ValidationError
+from schematics.exceptions import DataError
 
 
 def test_reason_why_we_must_bind_fields():
@@ -23,7 +23,7 @@ def test_reason_why_we_must_bind_fields():
 
     p1.name = "Jóhann"
     p1.validate()
-    with pytest.raises(ValidationError):
+    with pytest.raises(DataError):
         p2.validate()
 
     assert p1 != p2
@@ -55,7 +55,7 @@ def test_reason_why_we_must_bind_fields_model_field():
 
     p2.location = {}
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(DataError):
         p2.validate()
 
     assert p1 != p2

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from schematics.models import Model
+from schematics.types import *
+from schematics.types.compound import *
+from schematics.exceptions import *
+from schematics.undefined import Undefined
+
+
+def autofail(value, context):
+    raise ValidationError("Fubar!", info=99)
+
+class M(Model):
+    intfield = IntType(max_value=2)
+    reqfield = StringType(required=True)
+    matrixfield = ListType(ListType(IntType(max_value=2)))
+    listfield = ListType(IntType(), max_size=3, validators=[autofail])
+    modelfield = ModelType('M')
+
+
+def get_input_dict():
+
+    inputdict = {
+        'intfield': '1',
+        'reqfield': 'foo',
+        'listfield': [],
+        'modelfield': {
+            'reqfield': 'bar',
+            'listfield': [1, 2, 3, 4],
+            'modelfield': {
+                'intfield': '3',
+                'matrixfield': [[0, 1, 0, 1], [1, 2, 3, 4], ['1', '0', '1', '0']],
+                'listfield': None,
+                'modelfield': {
+                    'intfield': '0',
+                    'reqfield': 'foo',
+                    'listfield': None}}}}
+
+    return inputdict
+
+
+def get_input_instance(input_init):
+
+    inputinstance = M(init=input_init)
+    inputinstance.intfield = '1'
+    inputinstance.reqfield = 'foo'
+    inputinstance.listfield = []
+    inputinstance.modelfield = M(init=input_init)
+    inputinstance.modelfield.reqfield = 'bar'
+    inputinstance.modelfield.listfield = [1, 2, 3, 4]
+    inputinstance.modelfield.modelfield = M(init=input_init)
+    inputinstance.modelfield.modelfield.intfield = '3'
+    inputinstance.modelfield.modelfield.matrixfield = [[0, 1, 0, 1], [1, 2, 3, 4], ['1', '0', '1', '0']]
+    inputinstance.modelfield.modelfield.listfield = None
+    inputinstance.modelfield.modelfield.modelfield = M(init=input_init)
+    inputinstance.modelfield.modelfield.modelfield.intfield = '0'
+    inputinstance.modelfield.modelfield.modelfield.reqfield = 'foo'
+    inputinstance.modelfield.modelfield.modelfield.listfield = None
+
+    return inputinstance
+
+
+@pytest.fixture
+def input(input_instance, input_init):
+    if input_instance:
+        return get_input_instance(input_init)
+    else:
+        return get_input_dict()
+
+
+@pytest.mark.parametrize('input_instance, input_init, init,  missing_obj',
+                       [( False,          None,       True,  None),
+                        ( False,          None,       False, Undefined),
+                        ( True,           False,      True,  None),
+                        ( True,           False,      False, Undefined),
+                        ( True,           True,       True,  None),
+                        ( True,           True,       False, None)])
+def test_conversion(input, init, missing_obj):
+
+    m = M(input, init=init)
+
+    assert type(m.intfield) is int
+    assert type(m.modelfield.modelfield.intfield) is int
+    assert type(m.modelfield.modelfield.matrixfield[2][3]) is int
+
+    assert type(m.listfield) is list
+    assert type(m.modelfield) is M
+    assert type(m.modelfield.modelfield) is M
+    assert type(m.modelfield.modelfield.modelfield) is M
+    assert type(m.modelfield.listfield) is list
+    assert type(m.modelfield.modelfield.matrixfield) is list
+    assert type(m.modelfield.modelfield.matrixfield[2]) is list
+
+    assert m._data['listfield'] == []
+    assert m.modelfield._data['intfield'] is missing_obj
+    assert m.modelfield.modelfield._data['listfield'] is None
+    assert m.modelfield.modelfield._data['reqfield'] is missing_obj
+
+
+@pytest.mark.parametrize('partial', (True, False))
+@pytest.mark.parametrize('import_, two_pass, input_instance, input_init, init,  missing_obj',
+                       [( True,    False,    False,          None,       True,  None),
+                        ( True,    False,    False,          None,       False, Undefined),
+                        ( True,    False,    True,           False,      True,  None),
+                        ( True,    False,    True,           False,      False, Undefined),
+                        ( True,    False,    True,           True,       True,  None),
+                        ( True,    False,    True,           True,       False, None),
+                        ( True,    True,     False,          None,       True,  None),
+                        ( True,    True,     False,          None,       False, Undefined),
+                        ( True,    True,     True,           False,      True,  None),
+                        ( True,    True,     True,           False,      False, Undefined),
+                        ( True,    True,     True,           True,       True,  None),
+                        ( True,    True,     True,           True,       False, None),
+                        ( False,   None,     True,           False,      True,  None),
+                        ( False,   None,     True,           False,      False, Undefined),
+                        ( False,   None,     True,           True,       True,  None),
+                        ( False,   None,     True,           True,       False, None)])
+def test_conversion_with_validation(input, init, missing_obj, import_, two_pass, partial):
+
+    if missing_obj is None:
+        partial_data = {
+            'intfield': 1,
+            'reqfield': u'foo',
+            'matrixfield': None,
+            'modelfield': {
+                'intfield': None,
+                'reqfield': u'bar',
+                'matrixfield': None,
+                'modelfield': {
+                    'reqfield': None,
+                    'listfield': None,
+                    'modelfield': M({
+                        'intfield': 0,
+                        'reqfield': u'foo',
+                        'listfield': None})}}}
+    else:
+        partial_data = {
+            'intfield': 1,
+            'reqfield': u'foo',
+            'modelfield': {
+                'reqfield': u'bar',
+                'modelfield': {
+                    'listfield': None,
+                    'modelfield': M({
+                        'intfield': 0,
+                        'reqfield': u'foo',
+                        'listfield': None}, init=False)}}}
+
+    with pytest.raises(DataError) as excinfo:
+        if import_:
+            if two_pass:
+                m = M(input, init=init)
+                m.validate(partial=partial)
+            else:
+                M(input, init=init, partial=partial, validate=True)
+        else:
+            input.validate(init_values=init, partial=partial)
+
+    messages = excinfo.value.messages
+
+    err_list = messages.pop('listfield')
+    assert err_list.pop().type == ValidationError
+    assert err_list == []
+
+    err_list = messages['modelfield'].pop('listfield')
+    assert err_list.pop().type == ValidationError
+    assert err_list.pop().type == ValidationError
+    assert err_list == []
+
+    err_list = messages['modelfield']['modelfield'].pop('intfield')
+    err_msg = err_list.pop()
+    assert err_list == []
+    assert err_msg.type == ValidationError
+
+    if not partial:
+        err_list = messages['modelfield']['modelfield'].pop('reqfield')
+        err_msg = err_list.pop()
+        assert err_list == []
+        assert err_msg.type == ConversionError
+        if missing_obj is None:
+            partial_data['modelfield']['modelfield'].pop('reqfield')
+
+    err_dict = messages['modelfield']['modelfield'].pop('matrixfield')
+    sub_err_dict = err_dict.pop(1)
+    err_list_1 = sub_err_dict.pop(2)
+    err_list_2 = sub_err_dict.pop(3)
+    assert err_list_1.pop().type == ValidationError
+    assert err_list_2.pop().type == ValidationError
+    assert err_list_1 == err_list_2 == []
+    assert err_dict == sub_err_dict == {}
+
+    assert messages['modelfield'].pop('modelfield') == {}
+    assert messages.pop('modelfield') == {}
+    assert messages == {}
+
+    assert excinfo.value.partial_data == partial_data
+

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,9 +1,11 @@
+import copy
 import pickle
-from copy import copy, deepcopy
-from six import PY3
-import pytest
 
-from schematics.datastructures import OrderedDict, DataObject, ConfigObject
+import pytest
+from six import PY3
+from six.moves import zip
+
+from schematics.datastructures import OrderedDict, DataObject, Context
 
 
 def test_od_create():
@@ -26,7 +28,7 @@ def test_od_delete_key():
 def test_od_deepcopy():
     lst = [1, 2, 3]
     od = OrderedDict(a=lst)
-    new_od = deepcopy(od)
+    new_od = copy.deepcopy(od)
     new_od['a'].append(4)
 
     assert od['a'] is lst
@@ -157,7 +159,13 @@ def test_data_object_basics():
 
     d = DataObject({'x': 1, 'y': 2})
 
+    assert d == d
     assert d == DataObject(x=1, y=2)
+    assert d != DataObject(x=2, y=1)
+    assert d != {'x': 1, 'y': 2}
+
+    assert DataObject({'f': DataObject({'g': {'x': 1, 'y': 2}})}) \
+        != {'f': {'g': {'x': 1, 'y': 2}}}
 
     assert hasattr(d, 'x')
     assert 'x' in d
@@ -185,6 +193,10 @@ def test_data_object_basics():
         == set(d._items()) \
         == set((('x', 1), ('y', 2), ('z', 3)))
 
+    assert set((k for k, v in d)) \
+        == set(d._keys()) \
+        == set(('x', 'y', 'z'))
+
     x = d._pop('x')
     assert x == 1 and 'x' not in d
 
@@ -192,71 +204,85 @@ def test_data_object_basics():
     assert d.__dict__ == {}
 
 
-def test_data_object_dict_conversions():
-
-    config = {
-        'db': {
-            'mysql': {
-                'host': 'localhost',
-                'database': 'test',
-            },
-            'mongo': {
-                'host': 'localhost',
-                'database': 'test',
-            }
-        }
-    }
-
-    d = DataObject()
-    d.config = config
-
-    assert d.config.db.mysql.host == 'localhost'
-
-    assert d.config == DataObject({'db': DataObject(
-        {'mongo': DataObject({'host': 'localhost', 'database': 'test'}),
-         'mysql': DataObject({'host': 'localhost', 'database': 'test'})})})
-
-    assert d.config == DataObject({'db':
-        {'mongo': {'host': 'localhost', 'database': 'test'},
-         'mysql': {'host': 'localhost', 'database': 'test'}}})
-
-    assert config == d.config._to_dict()
-
-    d_copy = copy(d)
-    assert d_copy == d
-    assert id(d_copy) != id(d)
-    assert id(d_copy.config) == id(d.config)
-
-    d_deepcopy = deepcopy(d)
-    assert d_deepcopy == d
-    assert id(d_deepcopy) != id(d)
-    assert id(d_deepcopy.config) != id(d.config)
-
-
 def test_data_object_methods():
 
     d = DataObject({'x': 1})
     d._update({'y': 2})
-    d._update(DataObject({'z': 3}, q=0))
-    assert d == DataObject({'x': 1, 'y': 2, 'z': 3, 'q': 0})
+    d._update(DataObject({'z': 3}, q=4))
+    d._update(zip(('n', 'm'), (5, 6)))
+    assert d == DataObject({'x': 1, 'y': 2, 'z': 3, 'q': 4, 'n': 5, 'm': 6})
 
+    d = DataObject({'x': 1})
+    assert d._setdefault('x') == 1
     a = d._setdefault('a')
     assert a is None and d.a is None
-
     b = d._setdefault('b', 99)
     assert b == 99 and d.b == 99
-
     d._setdefaults({'i': 12, 'j': 23})
     assert d.i == 12 and d.j == 23
 
+    assert DataObject({'f': DataObject({'g': {'x': 1, 'y': 2}})})._to_dict() \
+        == {'f': {'g': {'x': 1, 'y': 2}}}
 
-def test_config_object():
 
-    d = ConfigObject(x=1, y=2)
-    assert 'x' in d
-    assert d.x == 1
-    assert d['x'] == 1
-    assert 'z' not in d
-    assert d.z is None
-    assert d['z'] is None
+def test_data_object_copy():
+
+    d = DataObject({'f': DataObject({'g': {'x': 1, 'y': 2}})})
+
+    d_copy = d._copy()
+    assert d_copy == d
+    assert id(d_copy) != id(d)
+    assert id(d_copy.f) == id(d.f)
+
+    d_deepcopy = copy.deepcopy(d)
+    assert d_deepcopy == d
+    assert id(d_deepcopy) != id(d)
+    assert id(d_deepcopy.f) != id(d.f)
+
+
+def test_context():
+
+    class FooContext(Context):
+        _fields = ('x', 'y', 'z')
+
+    assert bool(FooContext()) is True
+
+    c = FooContext(x=1, y=2)
+    assert c.__dict__ == dict(x=1, y=2)
+
+    with pytest.raises(ValueError):
+        FooContext(a=1)
+
+    with pytest.raises(Exception):
+        c.x = 0
+
+    c.z = 3
+    assert c.__dict__ == dict(x=1, y=2, z=3)
+
+    c = FooContext._new(1, 2, 3)
+    assert c.__dict__ == dict(x=1, y=2, z=3)
+
+    with pytest.raises(TypeError):
+        FooContext._new(1, 2, 3, 4)
+
+    d = c._branch()
+    assert d is c
+
+    d = c._branch(x=None)
+    assert d is c
+
+    d = c._branch(x=0)
+    assert d is not c
+    assert d.__dict__ == dict(x=0, y=2, z=3)
+
+    e = d._branch(x=0)
+    assert e is d
+
+    c = FooContext(x=1, y=2)
+    c._setdefaults(dict(x=9, z=9))
+    assert c.__dict__ == dict(x=1, y=2, z=9)
+
+    c = FooContext(x=1, y=2)
+    c._setdefaults(FooContext(x=9, z=9))
+    assert c.__dict__ == dict(x=1, y=2, z=9)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,98 @@
+import pytest
+
+from schematics.exceptions import *
 
 
+def test_error_from_string():
+
+    e = ConversionError('hello')
+    assert e.messages == ['hello']
+
+    e = ValidationError('hello', 'world', '!')
+    assert e.messages == ['hello', 'world', '!']
+    assert len(e) == 3
+
+
+def _assert(e):
+    assert e.messages == ['hello'] and e.messages[0].info == 99
+
+
+def test_error_from_args():
+    _assert(ValidationError('hello', info=99))
+
+
+def test_error_from_tuple():
+    _assert(ValidationError(('hello', 99)))
+
+
+def test_error_from_tuple():
+    msg = ErrorMessage('hello', info=99)
+    _assert(ValidationError(msg))
+
+
+def test_error_from_error():
+    e = ValidationError('hello', info=99)
+    _assert(ValidationError(e))
+
+
+def test_error_from_mixed_args():
+
+    e = ValidationError(
+            ('hello', 99),
+            ('world', 98),
+            ErrorMessage('from_msg', info=0),
+            ValidationError('from_err', info=1))
+
+    assert e == e.messages == ['hello', 'world', 'from_msg', 'from_err']
+    assert [msg.info for msg in e] == [99, 98, 0, 1]
+
+
+def test_error_from_mixed_list():
+
+    e = ConversionError([
+            ('hello', 99),
+            ('world', 98),
+            ErrorMessage('from_msg', info=0),
+            ConversionError('from_err', info=1)])
+
+    assert e.messages == ['hello', 'world', 'from_msg', 'from_err']
+    assert [msg.info for msg in e.messages] == [99, 98, 0, 1]
+
+
+def test_error_repr():
+
+    assert str(ValidationError('foo')) == 'ValidationError("foo", info=None)'
+
+    e = ValidationError(
+            ('foo', None),
+            ('bar', 98),
+            ('baz', [1, 2, 3]))
+
+    assert str(e) == 'ValidationError(("foo", None), ("bar", 98), ("baz", <\'list\' object>))'
+
+
+def test_error_message_object():
+
+    assert ErrorMessage('foo') == 'foo'
+    assert ErrorMessage('foo') != 'bar'
+    assert ErrorMessage('foo', 1) == ErrorMessage('foo', 1)
+    assert ErrorMessage('foo', 1) != ErrorMessage('foo', 2)
+
+
+def test_error_failures():
+
+    with pytest.raises(NotImplementedError):
+        FieldError()
+
+    with pytest.raises(TypeError):
+        ValidationError()
+
+    with pytest.raises(TypeError):
+        ValidationError('hello', 99)
+
+    with pytest.raises(TypeError):
+        ConversionError(ValidationError('hello'))
+
+    with pytest.raises(TypeError):
+        CompoundError(['hello'])
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,3 @@
-from schematics.exceptions import BaseError, ValidationError
 
 
-def test_clean_messages():
-    err = BaseError(None)
 
-    assert err.clean_messages({'foo': 'bar'}) == {'foo': 'bar'}
-    assert err.clean_messages({'foo': ValidationError('bar')}) == {'foo': ['bar']}
-    assert err.clean_messages(['foo']) == ['foo']
-    assert err.clean_messages([ValidationError('bar')]) == [['bar']]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,7 +1,7 @@
 from schematics.models import Model
 from schematics.types import IntType, StringType
 from schematics.validate import validate
-from schematics.exceptions import ValidationError
+from schematics.exceptions import ConversionError, ValidationError, DataError
 
 
 def test_validate_simple_dict():
@@ -76,7 +76,7 @@ def test_validate_with_instance_level_validators():
 
     try:
         validate(Player, p1)
-    except ValidationError as e:
+    except DataError as e:
         assert 'id' in e.messages
         assert 'Cannot change id' in e.messages['id']
         assert p1.id == 4

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -1,10 +1,9 @@
 import pytest
 
-from schematics.datastructures import ConfigObject
 from schematics.models import Model
 from schematics.types import IntType, StringType
 from schematics.types.compound import ModelType, ListType
-from schematics.exceptions import ValidationError
+from schematics.exceptions import DataError
 
 
 def test_simple_embedded_models():
@@ -17,7 +16,6 @@ def test_simple_embedded_models():
 
     r = repr(Player.location)
     assert r.startswith("<schematics.types.compound.ModelType object at 0x")
-    #assert r.endswith("for <class 'tests.test_model_type.Location'>>") #this assertion not compatible with PY3
 
     p = Player(dict(id=1, location={"country_code": "US"}))
 
@@ -94,7 +92,7 @@ def test_raises_validation_error_on_init_with_partial_submodel():
     u = User({'name': 'Arthur'})
     c = Card({'user': u})
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(DataError):
         c.validate()
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,7 +9,7 @@ import uuid
 
 import pytest
 
-from schematics.transforms import ExportContext
+from schematics.datastructures import Context
 from schematics.models import Model
 from schematics.types import (
     BaseType, StringType, DateTimeType, DateType, IntType, EmailType, LongType,
@@ -17,9 +17,7 @@ from schematics.types import (
     GeoPointType, FloatType, DecimalType
 )
 from schematics.types.base import get_range_endpoints
-from schematics.exceptions import (
-    ValidationError, ConversionError, MockCreationError
-)
+from schematics.exceptions import ConversionError, ValidationError, DataError
 
 
 _uuid = uuid.UUID('3ce85e48-3028-409c-a07c-c8ee3d16d5c4')
@@ -231,7 +229,7 @@ def test_url_type_with_unreachable_url():
 def test_string_type_required():
     class M(Model):
         field = StringType(required=True)
-    with pytest.raises(ValidationError):
+    with pytest.raises(DataError):
         M({'field': None}).validate()
 
 
@@ -347,7 +345,7 @@ def test_multilingual_string_should_emit_string_with_explicit_locale():
 
     assert mls.to_primitive(
         {'en_US': 'snake', 'fr_FR': 'serpent'},
-        context=ExportContext(app_data={'locale': 'fr_FR'})) == 'serpent'
+        context=Context(app_data={'locale': 'fr_FR'})) == 'serpent'
 
 
 def test_multilingual_string_should_require_a_locale():
@@ -364,7 +362,7 @@ def test_multilingual_string_without_matching_locale_should_explode():
         mls.to_primitive({'fr_FR': 'serpent'})
 
     with pytest.raises(ConversionError):
-        mls.to_primitive({'en_US': 'snake'}, context=ExportContext(app_data={'locale': 'fr_FR'}))
+        mls.to_primitive({'en_US': 'snake'}, context=Context(app_data={'locale': 'fr_FR'}))
 
 
 def test_multilingual_string_should_accept_lists_of_locales():
@@ -377,11 +375,11 @@ def test_multilingual_string_should_accept_lists_of_locales():
     mls = MultilingualStringType(default_locale=['foo', 'fr_FR', 'es_MX'])
 
     assert mls.to_primitive(strings) == 'serpent'
-    assert mls.to_primitive(strings, context=ExportContext(app_data={'locale': ['es_MX', 'bar']})) == 'serpiente'
+    assert mls.to_primitive(strings, context=Context(app_data={'locale': ['es_MX', 'bar']})) == 'serpiente'
 
     mls = MultilingualStringType()
 
-    assert mls.to_primitive(strings, context=ExportContext(app_data={'locale': ['foo', 'es_MX', 'fr_FR']})) == 'serpiente'
+    assert mls.to_primitive(strings, context=Context(app_data={'locale': ['foo', 'es_MX', 'fr_FR']})) == 'serpiente'
 
 
 def test_boolean_to_native():


### PR DESCRIPTION
This is a refactoring of the validation/conversion machinery that aims to
* further eliminate redundant code
* make the import recursion loop more generic and reusable
* make the exception flow and error aggregation easier to understand.

It introduces some new features made possible by the redesign and a few bugfixes as well.

Since the diff is pretty big, I'm going to explain most changes below.



### List of changes

* Combines the validation and conversion code paths. Recursive validation of nested items and submodels is now provided by `MultiType.convert()` (formerly `to_native()`), obviating the need for parallel, validation-specific logic.

  * The `validate_items()` methods on `ListType` and `DictType` are removed.
  * The `validate_model()` method on `ModelType` is removed.

* Enables simultaneous conversion and validation during data import.

  The statement `FooModel(<raw data>, validate=True)` now runs conversion and validation in one go, collecting both types of errors. If the data is likely to clear at least the conversion step, this is more efficient than sequential processing, which requires traversing the entire dataset twice.

  Here are some timing results from a simple import+validation testcase:

                       | Sequential | Single-pass  | Speedup |
  -------------------- | ---------: | -----------: |  -----: |
  Success              | 2.855      | 1.691        |  41%    |
  Fail on validation   | 3.164      | 2.003        |  37%    |
  Fail on conversion   | 1.533      | 2.077        | −35%    |

* Improves the exception design by implementing a bit more structure (see #369).
  * Clear separation between field-level and compound errors and their representations
  * Support for more detailed error data within the atomic messages

* Fixes the conversion of `ModelType` fields when the input is already a model instance. Previously, the instance would be returned unchanged even if it contained unconverted fields or submodels.

  If the process originates from `Model.__init__()`, a new instance is created for each submodel, and the input instance is simply used as the raw data, as would happen with a `dict` input. Otherwise, such as during validation, the existing instance is updated in place to preserve object identity.

* Makes the valid part of a failing dataset available to application code as `DataError.partial_data`.

  This information used to exist as `ModelConversionError.partial_data` but was only accessible to functions calling `import_loop` directly. It also wasn't aggregated to include submodels. Both of these issues are fixed, so the entire tree of valid data is now included with the final error raised from `Model.validate()` or similar.

* Fixes a bug where the first failing field-level validator would prevent the rest of a compound field's validators from running.

* Fixes a bug(?) that caused model-level validation to be skipped entirely if **any** errors occurred during field-level validation.

  From now on, only those fields that failed the initial validation are skipped, while others will have their model-level validators run normally.

* Removes `MultiType.validate()`. The `BaseType` implementation now works universally.

* Removes an obsolete validator `_check_for_unknown_fields()` from the `validate` module.

* Fixes a number of tests that were broken due to unreachable assertions inside `with pytest.raises()` statements.

* Changes `Context` back to a custom class from `namedtuple`. Turns out strict immutability is highly impractical because sometimes you have to establish a partial or empty context outside of `import_loop` to retain a reference to it. The new `Context` class implements a `__setattr__()` that allows setting each attribute just once, which provides the required degree of immutability.

* The instant conversion of `ModelType` fields when populated through assignment (as in `model_instance.submodel = {'x': 1}`) is now accomplished through a hook that types themselves may implement. This gets rid of the `isinstance` stuff inside `FieldDescriptor.__set__()` and eliminates the bidirectional module dependency.



### Compatibility

This is *mostly* just a reorganization that should not cause any huge trouble in a typical setting.

* Potential issues are likely to be related to the redesigned exceptions:

  * The switch from `list` to `dict` as the representation of nested `ListType` errors (#307) is clearly a backward-incompatible change, but it's done for a good reason.

  * Since `ValidationError` is a field-specific construct, aggregate error classes are no longer its subclasses. This will not work:

    ```python
    try:
        model_instance.validate()
    except ValidationError:
        ...
    ```

    Using `ModelValidationError` here *will* continue to work, as it's declared a synonym of `DataError`, as is `ModelConversionError`.

* If a derivative of `ListType` or `DictType` has overridden `validate_items()`, it would now cause validation to occur twice, since the original types no longer need this method. The same applies to `ModelType` and `validate_model()`.

* If a `Model` subclass has overridden the `validate()` method in the anticipation that it will be called for every submodel throughout a data tree, it will not work as expected. `Model.validate()` only initiates the validation process and is no longer invoked for submodels.

* Previously, the `data` dictionary passed to model-level validators would be guaranteed to contain entries for all fields because
  * the validators weren't called at all unless field-level validation was a complete success
  * `Undefined` objects would substitute for missing values (since #372).

  As both of these issues have now been remedied, validators wanting to look at other fields on the model will have to take care not to blindly access keys that might not exist.
