### PR TITLE
Performance optimizations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise AssertionError
+    raise NotImplementedError
+

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -154,6 +154,7 @@ class ModelMeta(type):
 
         # Ready meta data to be klass attributes
         attrs['_fields'] = fields
+        attrs['_field_list'] = list(fields.items())
         attrs['_serializables'] = serializables
         attrs['_validator_functions'] = validator_functions
         attrs['_options'] = options
@@ -345,7 +346,7 @@ class Model(object):
         return iter(self.keys())
 
     def keys(self):
-        return [k for k in self._fields if self._data[k] is not Undefined]
+        return [k for k, v in self._field_list if self._data[k] is not Undefined]
 
     def items(self):
         return [(k, self._data[k]) for k in self.keys()]

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 import inspect
+import itertools
 import sys
 
 from six import iteritems
@@ -172,6 +173,10 @@ class ModelMeta(type):
             field._setup(field_name, klass)
         for field_name, field in serializables.items():
             field._setup(field_name, klass)
+
+        klass._valid_input_keys = (
+            set(itertools.chain(*(field.get_input_keys() for field in fields.values())))
+          | set(serializables))
 
         return klass
 

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -2,12 +2,13 @@
 
 from __future__ import division
 
+import collections
 from collections import Iterable, Sequence, Mapping
 import itertools
 import functools
 
 from ..common import *
-from ..datastructures import Context
+from ..datastructures import Context, OrderedDict
 from ..exceptions import *
 from ..models import Model, ModelMeta
 from ..transforms import (
@@ -20,6 +21,11 @@ from six import iteritems
 from six import string_types as basestring
 from six import text_type as unicode
 from six.moves import xrange
+
+try:
+    ordered_mappings = (collections.OrderedDict, OrderedDict)
+except AttributeError:
+    ordered_mappings = (OrderedDict,) # Python 2.6
 
 
 class MultiType(BaseType):
@@ -168,12 +174,10 @@ class ListType(MultiType):
         elif isinstance(value, Sequence) and not isinstance(value, basestring):
             return value
         elif isinstance(value, Mapping):
-            try:
-                value.__reversed__ # indicates an ordered mapping
-            except AttributeError:
-                return [value[k] for k in sorted(value)]
-            else:
+            if isinstance(value, ordered_mappings):
                 return value.values()
+            else:
+                return [v for k, v in sorted(value.items())]
         elif isinstance(value, basestring):
             pass
         elif isinstance(value, Iterable):

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -45,8 +45,9 @@ def listify(value):
         return value
     elif value is None:
         return []
-    elif isinstance(value, collections.Sequence) \
-      and not isinstance(value, basestring):
+    elif isinstance(value, basestring):
+        return [value]
+    elif isinstance(value, collections.Sequence):
         return list(value)
     else:
         return [value]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py26, py27, py33, py34, py35, pypy, pypy3
 indexserver =
     pypi = https://pypi.python.org/simple
 


### PR DESCRIPTION
Whenever field-level conversion functions are inexpensive (as is typical), profiling indicates that the majority of time is spent in the main import/export loops. Their performance can be significantly improved with a few simple tweaks:

* Duplicate `Model._fields` as `Model._field_list` holding a native list of tuples, which is much faster to iterate over than the `OrderedDict`.
* In `atoms()`, retrieve values directly from `_data`, which is way faster than going through the class.
* Pre-build lists of trial input keys instead of computing them every time a field is encountered.
* Stop calling the redundant `wholelist()` filter as a fallback when no role is specified.

Making sure that Schematics runs on PyPy is probably more important for performance than most code optimizations, so I've added `pypy` and `pypy3` to the test environments.

