### PR TITLE
Introduce MixedType

### DIFF
--- a/schematics/types/__init__.py
+++ b/schematics/types/__init__.py
@@ -1,4 +1,5 @@
 from .base import *
+from .union import *
 from .net import *
 
 __all__ = [name for name, obj in globals().items() if isinstance(obj, TypeMeta)]

--- a/schematics/types/union.py
+++ b/schematics/types/union.py
@@ -1,0 +1,91 @@
+import inspect
+
+from ..common import *
+from ..datastructures import OrderedDict
+from ..exceptions import ConversionError
+from ..transforms import get_import_context, get_export_context
+from .base import BaseType
+
+
+def _valid_init_args(type_):
+    args = set()
+    for cls in type_.__mro__:
+        args.update(inspect.getargspec(cls.__init__).args[1:])
+        if cls is BaseType:
+            break
+    return args
+
+def _filter_kwargs(valid_args, kwargs):
+    return dict((k, v) for k, v in kwargs.items() if k in valid_args)
+
+
+class UnionType(BaseType):
+
+    types = None
+
+    MESSAGES = {
+        'convert': u"Couldn't interpret '{0}' value as any of {1}.",
+    }
+
+    _baseclass_args = _valid_init_args(BaseType)
+
+    def __init__(self, types=None, resolver=None, **kwargs):
+
+        self._types = OrderedDict()
+        types = types or self.types
+        if resolver:
+            self.resolve = resolver
+
+        for type_ in types:
+            if isinstance(type_, type) and issubclass(type_, BaseType):
+                type_ = type_(**_filter_kwargs(_valid_init_args(type_), kwargs))
+            elif not isinstance(type_, BaseType):
+                raise TypeError("Got '%s' instance instead of a Schematics type" % type_.__class__.__name__)
+            self._types[type_.__class__] = type_
+            self.typenames = tuple((cls.__name__ for cls in self._types))
+
+        super(UnionType, self).__init__(**_filter_kwargs(self._baseclass_args, kwargs))
+
+    def resolve(self, value, context):
+        for field in self._types.values():
+            try:
+                value = field.convert(value, context)
+            except ConversionError:
+                pass
+            else:
+                return field, value
+        return None
+
+    def _resolve(self, value, context):
+        response = self.resolve(value, context)
+        if isinstance(response, type):
+            field = self._types[response]
+            try:
+                response = field, field.convert(value, context)
+            except ConversionError:
+                pass
+        if isinstance(response, tuple):
+            return response
+        raise ConversionError(self.messages['convert'].format(value, self.typenames))
+
+    def convert(self, value, context=None):
+        context = context or get_import_context()
+        field, native_value = self._resolve(value, context)
+        return native_value
+
+    def validate(self, value, context=None):
+        field, _ = self._resolve(value, context)
+        return field.validate(value, context)
+
+    def _export(self, value, format, context=None):
+        field, _ = self._resolve(value, context)
+        return field._export(value, format, context)
+
+    def to_native(self, value, context=None):
+        field, _ = self._resolve(value, context)
+        return field.to_native(value, context)
+
+    def to_primitive(self, value, context=None):
+        field, _ = self._resolve(value, context)
+        return field.to_primitive(value, context)
+

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -101,7 +101,8 @@ def get_validation_context(**options):
         'partial': False,
         'strict': False,
         'convert': True,
-        'validate': True
+        'validate': True,
+        'new': False,
     }
     validation_options.update(options)
     return Context(**validation_options)

--- a/tests/test_union_type.py
+++ b/tests/test_union_type.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, division
+
+import pytest
+import uuid
+
+from schematics.common import *
+from schematics.exceptions import *
+from schematics.models import Model
+from schematics.types import *
+from schematics.types.compound import *
+from schematics.types.serializable import Serializable
+
+
+def test_id_or_uuid():
+
+    id_field = UnionType((IntType, UUIDType))
+
+    result = id_field.convert('ee5a16cb-0ee1-46bc-ac40-fb3018b1d29b')
+    assert result == uuid.UUID('ee5a16cb-0ee1-46bc-ac40-fb3018b1d29b')
+    assert type(id_field.to_primitive(result)) is str
+
+    result = id_field.convert('99999')
+    assert result == 99999
+    assert type(result) is int
+    assert type(id_field.to_primitive(result)) is int
+
+
+def test_list_of_numbers():
+
+    numbers = ListType(UnionType((IntType, FloatType)))
+    result = numbers.convert(["2", "0.5", "123", "2.999"], None)
+    assert result == [2, 0.5, 123, 2.999]
+    assert [type(item) for item in result] == [int, float, int, float]
+    assert [type(item) for item in numbers.to_primitive(result)] == [int, float, int, float]
+
+
+def test_dict_or_list_of_ints():
+
+    ints = UnionType((DictType, ListType), field=IntType)
+
+    result = ints.convert(["1", "2", "3", "4"])
+    assert result == [1, 2, 3, 4]
+    assert ints.to_primitive(result) == [1, 2, 3, 4]
+
+    result = ints.convert(dict(a=1, b=2, c=3, d=4))
+    assert result == dict(a=1, b=2, c=3, d=4)
+    assert [type(item) for item in result.values()] == [int, int, int, int]
+    assert ints.to_primitive(result) == dict(a=1, b=2, c=3, d=4)
+
+
+def test_custom_type():
+
+    class ShoutType(StringType):
+        def to_primitive(self, value, context):
+            return StringType.convert(self, value) + '!!!'
+
+    class QuestionType(StringType):
+        def to_primitive(self, value, context):
+            return StringType.convert(self, value) + '???'
+
+    class FancyStringType(UnionType):
+        types = (ShoutType, QuestionType)
+        def resolve(self, value, context):
+            if value.endswith('?'):
+                return QuestionType
+            elif value.endswith('!'):
+                return ShoutType
+
+    assert FancyStringType().to_primitive("Hello, world!") == "Hello, world!!!!"
+    assert FancyStringType().to_primitive("Who's a good boy?") == "Who's a good boy????"
+
+    def resolve(value, context):
+        if value.endswith('?'):
+            return QuestionType
+        elif value.endswith('!'):
+            return ShoutType
+
+    assert UnionType((ShoutType, QuestionType), resolver=resolve).to_primitive("Hello, world!") \
+        == "Hello, world!!!!"
+
+    with pytest.raises(ValidationError):
+        FancyStringType(max_length=20).validate("What is the meaning of life?")
+
+
+def test_option_collation():
+
+    class DerivedStringType(StringType):
+        pass
+
+    field = UnionType((IntType, DerivedStringType), required=True, max_value=100, max_length=50)
+    assert field.required is True
+    assert field._types[IntType].required is True
+    assert field._types[DerivedStringType].required is True
+    assert field._types[IntType].max_value == 100
+    assert field._types[DerivedStringType].max_length == 50
+
+
+def test_parameterize_validate():
+
+    UnionType((IntType(min_value=1, strict=True), FloatType(min_value=0))).validate(0.00)
+
+    UnionType((IntType(min_value=1), FloatType(min_value=0.5))).validate(0.75)
+    with pytest.raises(ValidationError):
+        UnionType((IntType(min_value=1), FloatType(min_value=0.5))).validate(0.00)
+
+
+def test_invalid_args():
+
+    with pytest.raises(TypeError):
+        UnionType((IntType, dict))
+


### PR DESCRIPTION
I've thought about PR #340 by @jmsdnns and decided to try to write a similar thing from scratch instead of adapting `PolyModelType`, since that one mostly consists of model-related machinery.

As explained in #340, saying "store value *x* with type *y*" is just not possible in the current Schematics architecture. However, as long as the type can be inferred from the value itself, it works great.

For now this thing is called `MixedType`.

### Examples

#### A field that takes a numeric ID or a UUID
```python
>>> id_field = MixedType((IntType, UUIDType))
>>> result = id_field.to_native('ee5a16cb-0ee1-46bc-ac40-fb3018b1d29b')
>>> result
UUID('ee5a16cb-0ee1-46bc-ac40-fb3018b1d29b')
>>> id_field.to_primitive(result)
'ee5a16cb-0ee1-46bc-ac40-fb3018b1d29b'
>>> id_field.to_native('99999')
99999
```

#### A list of ints or floats
```python
numbers = ListType(MixedType((IntType, FloatType)))
>>> result = numbers.to_native(["2", "0.5", "123", "2.999"])
>>> result
[2, 0.5, 123, 2.999]
>>> [type(item).__name__ for item in result]
['int', 'float', 'int', 'float']
```

#### A dict of ints or a list of ints
```python
ints = MixedType((DictType, ListType), field=IntType)
>>> ints.to_native([1, 2, 3, 4])
[1, 2, 3, 4]
>>> ints.to_native(dict(a=1, b=2, c=3, d=4))
{'a': 1, 'c': 3, 'b': 2, 'd': 4}
```

#### Complex situations

All the previous cases rely on `to_native` to detect the intended type. You can get quite far with that method by exploiting the fact that the types are evaluated in the original order. The most restrictive type must therefore appear first. In the second example, `FloatType` would have caught all items had the order been `(FloatType, IntType)`.

For more complex cases, make a subclass of `MixedType` and declare the resolution logic there:

```python
class ShoutType(StringType):
    def to_primitive(self, value, context):
        return StringType.to_native(self, value) + '!!!'

class QuestionType(StringType):
    def to_primitive(self, value, context):
        return StringType.to_native(self, value) + '???'

class FancyStringType(MixedType):

    # Declare the possible types, either as classes or parameterized instances.
    types = (ShoutType, QuestionType)

    # Override the method that detects the correct type. Return the appropriate class.
    def resolve(self, value, context):
        if value.endswith('?'):
            return QuestionType
        elif value.endswith('!'):
            return ShoutType
```

```python
>>> FancyStringType().to_primitive("Hello, world!")
'Hello, world!!!!'
>>> FancyStringType().to_primitive("Who's a good boy?")
"Who's a good boy????"
```

A resolver function can be provided in the field definition too:

```python
fancy_field = MixedType((ShoutType, QuestionType), resolver=resolve_func)
```

Alternatively, edit the inner *types* and orchestrate their `to_native` methods so that the first successful conversion is guaranteed to be the right one.

#### Parameterizing types

Arguments destined for the inner types may appear directly in the `MixedType` definition and are passed on, much like with compound types.

```python
>>> FancyStringType(max_length=20).validate("What is the meaning of life?")
Traceback (most recent call last):
  ...
schematics.exceptions.ValidationError: [u'String value is too long.']
```

Since there can be quite dissimilar types that accept various sets of parameters, `MixedType` inspects all `__init__()` argument lists in the types' MROs in order to figure out which parameters go where.

```python
>>> field = MixedType((IntType, QuestionType), required=True, max_value=100, max_length=50)
>>> field.required
True
>>> field._types[IntType].required
True
>>> field._types[QuestionType].required
True
>>> field._types[IntType].max_value
100
>>> field._types[QuestionType].max_length
50
```

#### Parameterizing types separately

Just make instances as usual.

```python
>>> field = MixedType((IntType(min_value=1), FloatType(min_value=0.5)))
>>> field.validate(0)
Traceback (most recent call last):
  ...
schematics.exceptions.ValidationError: [u'Int value should be greater than or equal to 1.']
>>> field.validate(0.75)
>>>
```
