### PR TITLE
Add example to DictType

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -149,6 +149,12 @@ class ModelType(CompoundType):
 class ListType(CompoundType):
     """A field for storing a list of items, all of which must conform to the type
     specified by the ``field`` parameter.
+
+    Use it like this:
+
+    .. code-block:: python
+        ...
+        categories = ListType(StringType)
     """
 
     def __init__(self, field, min_size=None, max_size=None, **kwargs):
@@ -244,9 +250,9 @@ class ListType(CompoundType):
 class DictType(CompoundType):
     """A field for storing a mapping of items, the values of which must conform to the type
     specified by the ``field`` parameter.
-    
+
     Use it like this:
-    
+
     .. code-block:: python
         ...
         categories = DictType(StringType)
@@ -401,4 +407,3 @@ class PolyModelType(CompoundType):
             raise Exception("Cannot export: {} is not an allowed type".format(model_class))
 
         return model_instance.export(context=context)
-

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -244,6 +244,13 @@ class ListType(CompoundType):
 class DictType(CompoundType):
     """A field for storing a mapping of items, the values of which must conform to the type
     specified by the ``field`` parameter.
+    
+    Use it like this:
+    
+    .. code-block:: python
+        ...
+        categories = DictType(StringType)
+
     """
 
     def __init__(self, field, coerce_key=None, **kwargs):


### PR DESCRIPTION
It is unclear if `type` is (1) a Python `type` (2) a schematics type defined in `schematics.types`. Adding an example clarifies which is which to avoid exceptions such as `AttributeError: 'str' object has no attribute 'owner_model'`.