### PR TITLE
Add support for arbitrary field metadata.

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -166,7 +166,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
     def __init__(self, required=False, default=Undefined, serialized_name=None,
                  choices=None, validators=None, deserialize_from=None,
                  export_level=None, serialize_when_none=None,
-                 messages=None, **kwargs):
+                 messages=None, metadata=None, **kwargs):
         super(BaseType, self).__init__()
 
         self.required = required
@@ -184,6 +184,7 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         self._set_export_level(export_level, serialize_when_none)
 
         self.messages = dict(self.MESSAGES, **(messages or {}))
+        self.metadata = metadata or {}
         self._position_hint = next(_next_position_hint)  # For ordering of fields
 
         self.name = None

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -150,7 +150,13 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
         class. A metaclass will merge all the `MESSAGES` and override the
         resulting dict with instance level `messages` and assign to
         `self.messages`.
-
+    :param metadata:
+        Dictionary for storing custom metadata associated with the field.  
+        To encourage compatibility with external tools, we suggest these keys 
+        for common metadata:
+        - *label* : Brief human-readable label
+        - *description* : Explanation of the purpose of the field. Used for 
+          help, tooltips, documentation, etc.
     """
 
     MESSAGES = {

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -436,3 +436,8 @@ def test_geopoint_range():
 
     with pytest.raises(ValidationError) as ve:
         geo.validate((28.2342323, 181.123141))
+
+def test_metadata():
+    metadata = {'description': 'amazing', 'extra': {'abc': 1}}
+    assert StringType(metadata=metadata).metadata == metadata
+    assert StringType().metadata == {}


### PR DESCRIPTION
Hi,
Here's a pull request for the metadata/annotations feature discussed in #333

It's dead simple.  I went with the name `metadata` instead of `annotations` because I think `metadata` is more self-explanatory, and I feel that `annotations` implies strings only.
