### PR TITLE
Code normalization for Python 3 + general cleanup

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,50 +1,37 @@
 [MASTER]
 
-# Specify a configuration file.
-#rcfile=
-
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
-
-# Profiled execution.
-profile=no
+init-hook=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=
 
 # Pickle collected data for later comparisons.
-persistent=yes
+persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 load-plugins=
 
-# DEPRECATED
-include-ids=no
-
-# DEPRECATED
-symbols=no
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
 
 
 [MESSAGES CONTROL]
 
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-#enable=
+# Enable the message, report, category or checker with the given id(s).
+enable=
 
-# Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifiers separated by comma (,) or put this
-# option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
-# you want to run only the similarities checker, you can use "--disable=all
-# --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
-#disable=
+# Disable the message, report, category or checker with the given id(s).
+disable=
+    bad-whitespace,bad-continuation,
+    wildcard-import, unused-wildcard-import,
+    protected-access,
+    unused-argument, too-many-arguments, too-many-branches
 
 
 [REPORTS]
@@ -53,11 +40,6 @@ symbols=no
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=yes
@@ -69,28 +51,21 @@ reports=yes
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
-
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
-#msg-template=
+msg-template=
 
 
 [BASIC]
 
-# Required attributes for module, separated by a comma
-required-attributes=
-
 # List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,apply,input,file
+bad-functions=apply,cmp,coerce,file,input,unicode
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=d,i,j,k,n,s,v,rv,ex,_
 
 # Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
+bad-names=foo,bar,baz
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.
@@ -100,19 +75,19 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-z_][a-z0-9_]{1,30}$
 
 # Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
+function-name-hint=[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
 
 # Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+variable-name-hint=[a-z_][a-z0-9_]{0,30}$
 
 # Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+const-rgx=(([A-Z_][A-Z0-9_]*)|_[a-z0-9_]+|(__.*__))$
 
 # Naming hint for constant names
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -136,10 +111,10 @@ class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+inlinevar-rgx=[a-z_][a-z0-9_]*$
 
 # Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+inlinevar-name-hint=[a-z_][a-z0-9_]*$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
@@ -165,16 +140,22 @@ no-docstring-rgx=__.*__
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
-docstring-min-length=-1
+docstring-min-length=2
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
 
 
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=115
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+ignore-long-lines=https?://
 
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
@@ -186,12 +167,14 @@ no-space-check=trailing-comma,dict-separator
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
-# tab).
+# String used as indentation unit.
 indent-string='    '
 
 # Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=LF
 
 
 [LOGGING]
@@ -204,7 +187,7 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+notes=FIXME,TODO
 
 
 [SIMILARITIES]
@@ -230,21 +213,19 @@ ignore-mixin-members=yes
 
 # List of module names for which member attributes should not be checked
 # (useful for modules/projects where namespaces are manipulated during runtime
-# and thus extisting member attributes cannot be deduced by static analysis
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
 ignored-modules=
 
 # List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set).
-ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=Model,Context
 
 # List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E0201 when accessed. Python regular
+# system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=REQUEST,acl_users,aq_parent
+generated-members=
 
 
 [VARIABLES]
@@ -254,27 +235,31 @@ init-import=no
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
-dummy-variables-rgx=_$|dummy
+dummy-variables-rgx=_$
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
 additional-builtins=
 
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=
+
 
 [CLASSES]
 
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
-
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+defining-attr-methods=__init__,__new__,setup,_setup
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
 valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source
 
 
 [DESIGN]
@@ -296,7 +281,7 @@ max-returns=6
 max-branches=12
 
 # Maximum number of statements in function / method body
-max-statements=50
+max-statements=100
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7
@@ -310,11 +295,14 @@ min-public-methods=2
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=3
+
 
 [IMPORTS]
 
 # Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,TERMIOS,Bastion,rexec
+deprecated-modules=
 
 # Create a graph of every (i.e. internal and external) dependencies in the
 # given file (report RP0402 must not be disabled)

--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -4,3 +4,5 @@ __version__ = '2.0.0.dev2'
 
 from .models import Model
 
+__all__ = ['Model']
+

--- a/schematics/common.py
+++ b/schematics/common.py
@@ -2,6 +2,11 @@
 
 from __future__ import unicode_literals, absolute_import
 
+# pylint: disable=unused-import
+import encodings.ascii
+import encodings.utf_8
+import encodings.unicode_escape
+
 from .compat import * # pylint: disable=redefined-builtin
 from .compat import __all__ as compat_exports
 from .util import module_exports, Constant

--- a/schematics/common.py
+++ b/schematics/common.py
@@ -1,4 +1,6 @@
-from .util import Constant
+from .compat import * # pylint: disable=redefined-builtin
+from .compat import __all__ as compat_exports
+from .util import module_exports, Constant
 
 
 NATIVE    = Constant('NATIVE',     0)
@@ -9,4 +11,7 @@ NONEMPTY  = Constant('NONEMPTY',   1)
 NOT_NONE  = Constant('NOT_NONE',   2)
 DEFAULT   = Constant('DEFAULT',   10)
 ALL       = Constant('ALL',       99)
+
+
+__all__ = module_exports(__name__) + compat_exports; __all__.append('module_exports')
 

--- a/schematics/common.py
+++ b/schematics/common.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, absolute_import
+
 from .compat import * # pylint: disable=redefined-builtin
 from .compat import __all__ as compat_exports
 from .util import module_exports, Constant

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -1,8 +1,12 @@
+from __future__ import absolute_import
+
+import functools
 import operator
 import sys
 
 
-__all__ = ['PY2', 'PY3', 'string_type', 'iteritems', 'metaclass']
+__all__ = ['PY2', 'PY3', 'string_type', 'iteritems', 'metaclass', 'py_native_string', 'str_compat']
+
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -30,4 +34,37 @@ def metaclass(metaclass):
         del attrs['__weakref__']
         return metaclass(cls.__name__, cls.__bases__, attrs)
     return make_class
+
+
+def py_native_string(source):
+    """
+    Converts Unicode strings to bytestrings on Python 2. The intended usage is to
+    wrap a function or a string in cases where Python 2 expects a native string.
+    """
+    if PY2:
+        if isinstance(source, str):
+            return source.encode('ascii')
+        elif callable(source):
+            @functools.wraps(source)
+            def new_func(*args, **kwargs):
+                rv = source(*args, **kwargs)
+                if isinstance(rv, str):
+                    rv = rv.encode('unicode-escape')
+                return rv
+            return new_func
+    return source
+
+
+def str_compat(class_):
+    """
+    On Python 2, patches the ``__str__`` and ``__repr__`` methods on the given class
+    so that the class can be written for Python 3 and Unicode.
+    """
+    if PY2:
+        if '__str__' in class_.__dict__ and '__unicode__' not in class_.__dict__:
+            class_.__unicode__ = class_.__str__
+            class_.__str__ = py_native_string(class_.__unicode__)
+        if '__repr__' in class_.__dict__:
+            class_.__repr__ = py_native_string(class_.__repr__)
+    return class_
 

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -1,0 +1,33 @@
+import operator
+import sys
+
+
+__all__ = ['PY2', 'PY3', 'string_type', 'iteritems', 'metaclass']
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+
+if PY2:
+    # pylint: disable=redefined-builtin,invalid-name,unused-import,wrong-import-position
+    __all__ += ['bytes', 'str', 'map', 'zip', 'range']
+    bytes = str
+    str = unicode
+    string_type = basestring
+    range = xrange
+    from itertools import imap as map
+    from itertools import izip as zip
+    iteritems = operator.methodcaller('iteritems')
+else:
+    string_type = str
+    iteritems = operator.methodcaller('items')
+
+
+def metaclass(metaclass):
+    def make_class(cls):
+        attrs = cls.__dict__.copy()
+        del attrs['__dict__']
+        del attrs['__weakref__']
+        return metaclass(cls.__name__, cls.__bases__, attrs)
+    return make_class
+

--- a/schematics/contrib/mongo.py
+++ b/schematics/contrib/mongo.py
@@ -2,16 +2,12 @@
 a part of the pymongo distribution.
 """
 
-from schematics.types import BaseType
-from schematics.exceptions import ConversionError, ValidationError
-
 import bson
 
-try:
-    unicode #PY2
-except:
-    import codecs
-    unicode = str #PY3
+from ..common import * # pylint: disable=redefined-builtin
+from ..types import BaseType
+from ..exceptions import ConversionError, ValidationError
+
 
 class ObjectIdType(BaseType):
 
@@ -33,7 +29,7 @@ class ObjectIdType(BaseType):
     def to_native(self, value, context=None):
         if not isinstance(value, bson.objectid.ObjectId):
             try:
-                value = bson.objectid.ObjectId(unicode(value))
+                value = bson.objectid.ObjectId(str(value))
             except bson.objectid.InvalidId:
                 raise ConversionError(self.messages['convert'])
         return value

--- a/schematics/contrib/mongo.py
+++ b/schematics/contrib/mongo.py
@@ -2,6 +2,8 @@
 a part of the pymongo distribution.
 """
 
+from __future__ import unicode_literals, absolute_import
+
 import bson
 
 from ..common import * # pylint: disable=redefined-builtin
@@ -19,7 +21,7 @@ class ObjectIdType(BaseType):
     """
 
     MESSAGES = {
-        'convert': u"Couldn't interpret value as an ObjectId.",
+        'convert': "Couldn't interpret value as an ObjectId.",
     }
 
     def __init__(self, auto_fill=False, **kwargs):

--- a/schematics/contrib/mongo.py
+++ b/schematics/contrib/mongo.py
@@ -8,7 +8,7 @@ import bson
 
 from ..common import * # pylint: disable=redefined-builtin
 from ..types import BaseType
-from ..exceptions import ConversionError, ValidationError
+from ..exceptions import ConversionError
 
 
 class ObjectIdType(BaseType):

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, absolute_import
+
 from collections import namedtuple
 from copy import deepcopy
 

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+# pylint: skip-file
 
 from __future__ import unicode_literals, absolute_import
 
-from collections import namedtuple
 from copy import deepcopy
 
 from .common import * # pylint: disable=redefined-builtin

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -1,11 +1,10 @@
 from collections import namedtuple
 from copy import deepcopy
-from six.moves import zip
-from six import iteritems
-from six import PY3
+
+from .common import * # pylint: disable=redefined-builtin
+
 
 _missing = object()
-
 
 class OrderedDict(dict):
 

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -1,9 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, absolute_import
+
 from collections import Iterable
 
 from .common import * # pylint: disable=redefined-builtin
 from .util import listify
 
 
+@str_compat
 class ErrorMessage(object):
 
     def __init__(self, summary, info=None):
@@ -41,6 +46,7 @@ class BaseError(Exception):
     pass
 
 
+@str_compat
 class FieldError(BaseError):
 
     type = None
@@ -99,7 +105,7 @@ class FieldError(BaseError):
             msg = self.messages[0]
             msg_repr = '"{0}", info={1}'.format(msg.summary, msg.info_repr)
         else:
-            msg_repr = str.join(u', ',
+            msg_repr = str.join(', ',
                                 ('("{0}", {1})'.format(msg.summary, msg.info_repr)
                                  for msg in self.messages))
         return '{0}({1})'.format(type(self).__name__, msg_repr)

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -1,15 +1,7 @@
 from collections import Iterable
 
-from six import iteritems
-
+from .common import * # pylint: disable=redefined-builtin
 from .util import listify
-
-try:
-    basestring #PY2
-    bytes = str
-except NameError:
-    basestring = str #PY3
-    unicode = str
 
 
 class ErrorMessage(object):
@@ -31,7 +23,7 @@ class ErrorMessage(object):
             return 'None'
         elif isinstance(self.info, int):
             return self.info
-        elif isinstance(self.info, basestring):
+        elif isinstance(self.info, string_type):
             return '"{0}"'.format(self.info)
         else:
             return "<'{0}' object>".format(type(self.info).__name__)
@@ -39,7 +31,7 @@ class ErrorMessage(object):
     def __eq__(self, other):
         if isinstance(other, ErrorMessage):
             return self.__dict__ == other.__dict__
-        elif isinstance(other, basestring):
+        elif isinstance(other, string_type):
             return self.summary == other
         else:
             return False
@@ -67,7 +59,7 @@ class FieldError(BaseError):
             items = args
         self.messages = []
         for item in items:
-            if isinstance(item, basestring):
+            if isinstance(item, string_type):
                 self.messages.append(ErrorMessage(item))
             elif isinstance(item, tuple):
                 self.messages.append(ErrorMessage(*item))
@@ -107,7 +99,7 @@ class FieldError(BaseError):
             msg = self.messages[0]
             msg_repr = '"{0}", info={1}'.format(msg.summary, msg.info_repr)
         else:
-            msg_repr = str.join(', ',
+            msg_repr = str.join(u', ',
                                 ('("{0}", {1})'.format(msg.summary, msg.info_repr)
                                  for msg in self.messages))
         return '{0}({1})'.format(type(self).__name__, msg_repr)
@@ -172,4 +164,7 @@ class MissingValueError(AttributeError, KeyError):
 class UnknownFieldError(KeyError):
     """Exception raised when attempting to set a nonexistent field using the subscription syntax."""
     pass
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -14,22 +14,22 @@ class ErrorMessage(object):
         self.summary = summary
         self.info = info
 
-    def __str__(self):
-        return self.summary
-
     def __repr__(self):
-        return '{0}("{1}", info={2})'.format(type(self).__name__, self.summary, self.info_repr)
+        return '%s(%s)' % (self.__class__.__name__, str(self))
 
-    @property
-    def info_repr(self):
-        if self.info is None:
-            return 'None'
-        elif isinstance(self.info, int):
-            return self.info
-        elif isinstance(self.info, string_type):
-            return '"{0}"'.format(self.info)
+    def __str__(self):
+        if self.info:
+            return '("%s", %s)' % (self.summary, self._info_as_str())
         else:
-            return "<'{0}' object>".format(type(self.info).__name__)
+            return '"%s"' % self.summary
+
+    def _info_as_str(self):
+        if isinstance(self.info, int):
+            return str(self.info)
+        elif isinstance(self.info, string_type):
+            return '"%s"' % self.info
+        else:
+            return "<'%s' object>" % self.info.__class__.__name__
 
     def __eq__(self, other):
         if isinstance(other, ErrorMessage):
@@ -100,13 +100,10 @@ class FieldError(BaseError):
 
     def __repr__(self):
         if len(self.messages) == 1:
-            msg = self.messages[0]
-            msg_repr = '"{0}", info={1}'.format(msg.summary, msg.info_repr)
+            msg_repr = str(self.messages[0])
         else:
-            msg_repr = str.join(', ',
-                                ('("{0}", {1})'.format(msg.summary, msg.info_repr)
-                                 for msg in self.messages))
-        return '{0}({1})'.format(type(self).__name__, msg_repr)
+            msg_repr = '[' + str.join(', ', map(str, self.messages)) + ']'
+        return '%s(%s)' % (self.__class__.__name__, msg_repr)
 
     __str__ = __repr__
 

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -2,8 +2,6 @@
 
 from __future__ import unicode_literals, absolute_import
 
-from collections import Iterable
-
 from .common import * # pylint: disable=redefined-builtin
 from .util import listify
 
@@ -79,12 +77,12 @@ class FieldError(BaseError):
         for message in self.messages:
             message.type = self.type or type(self)
 
-        Exception.__init__(self, self.messages)
+        super(FieldError, self).__init__(self.messages)
 
     def __eq__(self, other):
         if type(other) is type(self):
             return other.messages == self.messages
-        elif type(other) is list:
+        elif isinstance(other, list):
             return other == self.messages
         return False
 
@@ -144,7 +142,7 @@ class CompoundError(BaseError):
                 self.messages[key] = value.messages
             else:
                 self.messages[key] = value
-        Exception.__init__(self, self.messages)
+        super(CompoundError, self).__init__(self.messages)
 
 
 class DataError(CompoundError):

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -412,23 +412,26 @@ class Model(object):
         return not self == other
 
     def __repr__(self):
-        try:
-            obj = str(self)
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            obj = '[Bad Unicode data]'
+        model = self.__class__.__name__
+        info = self._repr_info()
+        if info:
+            return '<%s: %s>' % (model, info)
+        else:
+            return '<%s instance>' % model
 
-        try:
-            class_name = str(self.__class__.__name__)
-        except (UnicodeEncodeError, UnicodeDecodeError):
-            class_name = '[Bad Unicode class name]'
+    def _repr_info(self):
+        """
+        Subclasses may implement this method to augment the ``__repr__()`` output for the instance::
 
-        return "<%s: %s>" % (class_name, obj)
+            class Person(Model):
+                ...
+                def _repr_info(self):
+                    return self.name
 
-    def __str__(self):
-        return '%s object' % self.__class__.__name__
-
-    def __unicode__(self):
-        return '%s object' % self.__class__.__name__
+            >>> Person({'name': 'Mr. Pink'})
+            <Person: Mr. Pink>
+        """
+        return None
 
 
 __all__ = module_exports(__name__)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -5,25 +5,18 @@ import inspect
 import itertools
 import sys
 
-from six import iteritems
-from six import iterkeys
-from six import add_metaclass
-
-from .common import *
+from .common import * # pylint: disable=redefined-builtin
 from .datastructures import OrderedDict as OrderedDictWithSort
-from .exceptions import (
-    BaseError, DataError, MockCreationError,
-    MissingValueError, UnknownFieldError
+from .exceptions import *
+from .transforms import (
+    atoms, export_loop,
+    convert, to_native, to_dict, to_primitive,
+    flatten, expand
 )
+from .validate import validate, prepare_validator
 from .types import BaseType
 from .types.serializable import Serializable
 from .undefined import Undefined
-
-try:
-    unicode #PY2
-except:
-    import codecs
-    unicode = str #PY3
 
 
 class FieldDescriptor(object):
@@ -213,7 +206,7 @@ class ModelMeta(type):
         return cls._fields
 
 
-@add_metaclass(ModelMeta)
+@metaclass(ModelMeta)
 class Model(object):
 
     """
@@ -418,12 +411,12 @@ class Model(object):
 
     def __repr__(self):
         try:
-            obj = unicode(self)
+            obj = str(self)
         except (UnicodeEncodeError, UnicodeDecodeError):
             obj = '[Bad Unicode data]'
 
         try:
-            class_name = unicode(self.__class__.__name__)
+            class_name = str(self.__class__.__name__)
         except (UnicodeEncodeError, UnicodeDecodeError):
             class_name = '[Bad Unicode class name]'
 
@@ -436,9 +429,5 @@ class Model(object):
         return '%s object' % self.__class__.__name__
 
 
-from .transforms import (
-    atoms, export_loop,
-    convert, to_native, to_dict, to_primitive,
-    flatten, expand,
-)
-from .validate import validate, prepare_validator
+__all__ = module_exports(__name__)
+

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals, absolute_import
 from copy import deepcopy
 import inspect
 import itertools
-import sys
 
 from .common import * # pylint: disable=redefined-builtin
 from .datastructures import OrderedDict as OrderedDictWithSort

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals, absolute_import
+
 from copy import deepcopy
 import inspect
 import itertools
@@ -154,6 +156,7 @@ class ModelMeta(type):
         attrs['_options'] = options
 
         klass = type.__new__(mcs, name, bases, attrs)
+        klass = str_compat(klass)
 
         # Register class on ancestor models
         klass._subclasses = []
@@ -420,7 +423,7 @@ class Model(object):
         except (UnicodeEncodeError, UnicodeDecodeError):
             class_name = '[Bad Unicode class name]'
 
-        return u"<%s: %s>" % (class_name, obj)
+        return "<%s: %s>" % (class_name, obj)
 
     def __str__(self):
         return '%s object' % self.__class__.__name__

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -7,24 +7,11 @@ import itertools
 import operator
 import types
 
-from six import iteritems
-
-from .common import *
+from .common import * # pylint: disable=redefined-builtin
 from .datastructures import OrderedDict, Context
 from .exceptions import *
 from .undefined import Undefined
 from .util import listify
-
-try:
-    basestring #PY2
-except NameError:
-    basestring = str #PY3
-
-try:
-    unicode #PY2
-except:
-    import codecs
-    unicode = str #PY3
 
 
 
@@ -679,7 +666,7 @@ def flatten_to_dict(instance_or_dict, prefix=None, ignore_none=True):
     flat_dict = {}
     for key, value in iterator:
         if prefix:
-            key = ".".join(map(unicode, (prefix, key)))
+            key = ".".join(map(str, (prefix, key)))
 
         if value == []:
             value = EMPTY_LIST
@@ -742,4 +729,7 @@ def flatten(cls, instance_or_dict, role=None, raise_error_on_role=True,
     flattened = flatten_to_dict(data, prefix=prefix, ignore_none=ignore_none)
 
     return flattened
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -343,7 +343,6 @@ class Role(collections.Set):
         return len(self.fields)
 
     def __eq__(self, other):
-        print(dir(self.function))
         return (self.function.__name__ == other.function.__name__ and
                 self.fields == other.fields)
 

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import unicode_literals, absolute_import
 
 import collections
 import itertools
@@ -210,7 +210,7 @@ def export_loop(cls, instance_or_dict, field_converter=None, role=None, raise_er
     filter_func = cls._options.roles.get(context.role)
     if filter_func is None:
         if context.role and context.raise_error_on_role:
-            error_msg = u'%s Model has no role "%s"'
+            error_msg = '%s Model has no role "%s"'
             raise ValueError(error_msg % (cls.__name__, context.role))
         else:
             filter_func = cls._options.roles.get("default")
@@ -310,6 +310,7 @@ def atoms(cls, instance_or_dict):
 # Field filtering
 ###
 
+@str_compat
 class Role(collections.Set):
 
     """
@@ -641,9 +642,9 @@ def flatten_to_dict(instance_or_dict, prefix=None, ignore_none=True):
 
         {
             's': 'jms was hrrr',
-            u'l.1': 'here',
-            u'l.0': 'jms was here',
-            u'l.2': 'and here'
+            'l.1': 'here',
+            'l.0': 'jms was here',
+            'l.2': 'and here'
         }
 
     :param instance_or_dict:
@@ -701,7 +702,7 @@ def flatten(cls, instance_or_dict, role=None, raise_error_on_role=True,
         >>> f.l = ['jms', 'was here', 'and here']
 
         >>> flatten(Foo, f)
-        {'s': 'string', u'l.1': 'jms', u'l.0': 'was here', u'l.2': 'and here'}
+        {'s': 'string', 'l.1': 'jms', 'l.0': 'was here', 'l.2': 'and here'}
 
     :param cls:
         The model definition.

--- a/schematics/types/__init__.py
+++ b/schematics/types/__init__.py
@@ -1,2 +1,4 @@
 from .base import *
 from .net import *
+
+__all__ = [name for name, obj in globals().items() if isinstance(obj, TypeMeta)]

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -182,6 +182,15 @@ class BaseType(object):
         self.export_mapping = dict(
             (format, getattr(self, fname)) for format, fname in self.EXPORT_METHODS.items())
 
+    def __repr__(self):
+        type_ = "%s(%s) instance" % (self.__class__.__name__, self._repr_info() or '')
+        model = " on %s" % self.owner_model.__name__ if self.owner_model else ''
+        field = " as '%s'" % self.name if self.name else ''
+        return "<%s>" % (type_ + model + field)
+
+    def _repr_info(self):
+        return None
+
     def __call__(self, value, context=None):
         return self.convert(value, context)
 

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals, absolute_import
+
+import codecs
 import copy
 import math
 import uuid
@@ -142,8 +145,8 @@ class BaseType(object):
     """
 
     MESSAGES = {
-        'required': u"This field is required.",
-        'choices': u"Value must be one of {0}.",
+        'required': "This field is required.",
+        'choices': "Value must be one of {0}.",
     }
 
     EXPORT_METHODS = {
@@ -719,12 +722,12 @@ class DateTimeType(BaseType):
         'validate_utc_wrong': u'Time zone must be UTC.',
     }
 
-    REGEX = re.compile(
-             u'(?P<year>\d{4})-(?P<month>\d\d)-(?P<day>\d\d)(?:T|\ )'
-             u'(?P<hour>\d\d):(?P<minute>\d\d)'
-             u'(?::(?P<second>\d\d)(?:(?:\.|,)(?P<sec_frac>\d{1,6}))?)?'
-             u'(?:(?P<tzd_offset>(?P<tzd_sign>[+−-])(?P<tzd_hour>\d\d):?(?P<tzd_minute>\d\d)?)'
-             u'|(?P<tzd_utc>Z))?$', re.X)
+    REGEX = re.compile(r"""
+                (?P<year>\d{4})-(?P<month>\d\d)-(?P<day>\d\d)(?:T|\ )
+                (?P<hour>\d\d):(?P<minute>\d\d)
+                (?::(?P<second>\d\d)(?:(?:\.|,)(?P<sec_frac>\d{1,6}))?)?
+                (?:(?P<tzd_offset>(?P<tzd_sign>[+−-])(?P<tzd_hour>\d\d):?(?P<tzd_minute>\d\d)?)
+                |(?P<tzd_utc>Z))?$""", re.X)
 
     TIMEDELTA_ZERO = datetime.timedelta(0)
 

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -102,8 +102,8 @@ class ModelType(CompoundType):
 
         super(ModelType, self).__init__(**kwargs)
 
-    def __repr__(self):
-        return object.__repr__(self)[:-1] + ' for %s>' % self.model_class
+    def _repr_info(self):
+        return self.model_class.__name__
 
     def _mock(self, context=None):
         return self.model_class.get_mock_object(context)
@@ -162,6 +162,9 @@ class ListType(CompoundType):
     @property
     def model_class(self):
         return self.field.model_class
+
+    def _repr_info(self):
+        return self.field.__class__.__name__
 
     def _mock(self, context=None):
         min_size = self.min_size or 1
@@ -260,6 +263,9 @@ class DictType(CompoundType):
     def model_class(self):
         return self.field.model_class
 
+    def _repr_info(self):
+        return self.field.__class__.__name__
+
     def _convert(self, value, context, safe=False):
         if not isinstance(value, dict):
             raise ConversionError('Only dictionaries may be used in a DictType')
@@ -315,9 +321,6 @@ class PolyModelType(CompoundType):
         self.allow_subclasses = kwargs.pop("allow_subclasses", allow_subclasses)
 
         CompoundType.__init__(self, **kwargs)
-
-    def __repr__(self):
-        return object.__repr__(self)[:-1] + ' for %s>' % str(self.model_classes)
 
     def _setup(self, field_name, owner_model):
         # Resolve possible name-based model references.

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -7,7 +7,7 @@ from collections import Iterable, Sequence, Mapping
 import itertools
 import functools
 
-from ..common import *
+from ..common import * # pylint: disable=redefined-builtin
 from ..datastructures import Context, OrderedDict
 from ..exceptions import *
 from ..models import Model, ModelMeta
@@ -15,12 +15,8 @@ from ..transforms import (
     get_import_context, get_export_context,
     to_native_converter, to_dict_converter, to_primitive_converter)
 from ..undefined import Undefined
-from .base import BaseType, get_value_in
 
-from six import iteritems
-from six import string_types as basestring
-from six import text_type as unicode
-from six.moves import xrange
+from .base import BaseType, get_value_in
 
 try:
     ordered_mappings = (collections.OrderedDict, OrderedDict)
@@ -99,7 +95,7 @@ class ModelType(CompoundType):
         if isinstance(model_spec, ModelMeta):
             self.model_class = model_spec
             self.model_name = self.model_class.__name__
-        elif isinstance(model_spec, basestring):
+        elif isinstance(model_spec, string_type):
             self.model_class = None
             self.model_name = model_spec
         else:
@@ -177,19 +173,19 @@ class ListType(CompoundType):
             raise MockCreationError(message)
         random_length = get_value_in(min_size, max_size)
 
-        return [self.field._mock(context) for _ in xrange(random_length)]
+        return [self.field._mock(context) for _ in range(random_length)]
 
     def _coerce(self, value):
         if isinstance(value, list):
             return value
-        elif isinstance(value, Sequence) and not isinstance(value, basestring):
+        elif isinstance(value, Sequence) and not isinstance(value, string_type):
             return value
         elif isinstance(value, Mapping):
             if isinstance(value, ordered_mappings):
                 return value.values()
             else:
                 return [v for k, v in sorted(value.items())]
-        elif isinstance(value, basestring):
+        elif isinstance(value, string_type):
             pass
         elif isinstance(value, Iterable):
             return value
@@ -259,7 +255,7 @@ class DictType(CompoundType):
 
     def __init__(self, field, coerce_key=None, **kwargs):
         self.field = self._init_field(field, kwargs)
-        self.coerce_key = coerce_key or unicode
+        self.coerce_key = coerce_key or str
         super(DictType, self).__init__(**kwargs)
 
     @property
@@ -307,7 +303,7 @@ class PolyModelType(CompoundType):
 
     def __init__(self, model_spec, **kwargs):
 
-        if isinstance(model_spec, (ModelMeta, basestring)):
+        if isinstance(model_spec, (ModelMeta, string_type)):
             self.model_classes = (model_spec,)
             allow_subclasses = True
         elif isinstance(model_spec, Iterable):
@@ -329,7 +325,7 @@ class PolyModelType(CompoundType):
         # Resolve possible name-based model references.
         resolved_classes = []
         for m in self.model_classes:
-            if isinstance(m, basestring):
+            if isinstance(m, string_type):
                 if m == owner_model.__name__:
                     resolved_classes.append(owner_model)
                 else:
@@ -405,4 +401,7 @@ class PolyModelType(CompoundType):
             raise Exception("Cannot export: {} is not an allowed type".format(model_class))
 
         return model_instance.export(context=context)
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
+from __future__ import unicode_literals, absolute_import
 
 import collections
 from collections import Iterable, Sequence, Mapping
@@ -133,7 +133,7 @@ class ModelType(CompoundType):
             model_class = self.model_class
         else:
             raise ConversionError(
-                u'Please use a mapping for this field or {0} instance instead of {1}.'.format(
+                'Please use a mapping for this field or {0} instance instead of {1}.'.format(
                     self.model_class.__name__,
                     type(value).__name__))
         return model_class._convert(value, context=context)
@@ -169,7 +169,7 @@ class ListType(CompoundType):
         min_size = self.min_size or 1
         max_size = self.max_size or 1
         if min_size > max_size:
-            message = u'Minimum list size is greater than maximum list size.'
+            message = 'Minimum list size is greater than maximum list size.'
             raise MockCreationError(message)
         random_length = get_value_in(min_size, max_size)
 
@@ -209,15 +209,15 @@ class ListType(CompoundType):
 
         if self.min_size is not None and list_length < self.min_size:
             message = ({
-                True: u'Please provide at least %d item.',
-                False: u'Please provide at least %d items.',
+                True: 'Please provide at least %d item.',
+                False: 'Please provide at least %d items.',
             }[self.min_size == 1]) % self.min_size
             raise ValidationError(message)
 
         if self.max_size is not None and list_length > self.max_size:
             message = ({
-                True: u'Please provide no more than %d item.',
-                False: u'Please provide no more than %d items.',
+                True: 'Please provide no more than %d item.',
+                False: 'Please provide no more than %d items.',
             }[self.max_size == 1]) % self.max_size
             raise ValidationError(message)
 
@@ -264,7 +264,7 @@ class DictType(CompoundType):
 
     def _convert(self, value, context, safe=False):
         if not isinstance(value, dict):
-            raise ConversionError(u'Only dictionaries may be used in a DictType')
+            raise ConversionError('Only dictionaries may be used in a DictType')
 
         data = {}
         errors = {}
@@ -356,7 +356,7 @@ class PolyModelType(CompoundType):
                     cls.__name__ for cls in self.model_classes))
             else:
                 instanceof_msg = self.model_classes[0].__name__
-            raise ConversionError(u'Please use a mapping for this field or '
+            raise ConversionError('Please use a mapping for this field or '
                                     'an instance of {}'.format(instanceof_msg))
 
         model_class = self.find_model(value)

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -5,16 +5,14 @@ from __future__ import unicode_literals, absolute_import
 import collections
 from collections import Iterable, Sequence, Mapping
 import itertools
-import functools
 
 from ..common import * # pylint: disable=redefined-builtin
-from ..datastructures import Context, OrderedDict
+from ..datastructures import OrderedDict
 from ..exceptions import *
 from ..models import Model, ModelMeta
 from ..transforms import (
     get_import_context, get_export_context,
     to_native_converter, to_dict_converter, to_primitive_converter)
-from ..undefined import Undefined
 
 from .base import BaseType, get_value_in
 

--- a/schematics/types/net.py
+++ b/schematics/types/net.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
+from __future__ import unicode_literals, absolute_import
 
-from encodings import idna
+import encodings.idna
 import random
 import re
 
@@ -27,24 +27,24 @@ from .base import StringType
 hex      = '0-9A-F'
 alpha    = 'A-Z'
 alphanum = 'A-Z0-9'
-ucs      = (u'\u00A0-\uD7FF'
-            u'\uF900-\uFDCF'
-            u'\uFDF0-\uFFEF')
-private  =  u'\uE000-\uF8FF'
+ucs      = ('\u00A0-\uD7FF'
+            '\uF900-\uFDCF'
+            '\uFDF0-\uFFEF')
+private  =  '\uE000-\uF8FF'
 
-if len(u'\U0002000B') == 1: # Indicates that code points beyond the BMP are supported.
-    ucs     += u'\U00010000-\U000EFFFF'
-    private += u'\U000F0000-\U0010FFFD'
+if len('\U0002000B') == 1: # Indicates that code points beyond the BMP are supported.
+    ucs     += '\U00010000-\U000EFFFF'
+    private += '\U000F0000-\U0010FFFD'
 
 
 ### IP address patterns
 
 ipv4_octet = '( 25[0-5] | 2[0-4][0-9] | [0-1]?[0-9]{1,2} )'
-ipv4 = '( ((%(oct)s\.){3} %(oct)s) )' % {'oct': ipv4_octet}
+ipv4 = r'( ((%(oct)s\.){3} %(oct)s) )' % {'oct': ipv4_octet}
 
 ipv6_h16 = '[%s]{1,4}' % hex
 ipv6_l32 = '(%(h16)s:%(h16)s|%(ipv4)s)' % {'h16': ipv6_h16, 'ipv4': ipv4}
-ipv6 = u"""(
+ipv6 = r"""(
                                     (%(h16)s:){6}%(l32)s  |
                                 ::  (%(h16)s:){5}%(l32)s  |
     (               %(h16)s )?  ::  (%(h16)s:){4}%(l32)s  |
@@ -121,8 +121,8 @@ class URLType(StringType):
     """
 
     MESSAGES = {
-        'invalid_url': u"Not a well-formed URL.",
-        'not_found': u"URL could not be retrieved.",
+        'invalid_url': "Not a well-formed URL.",
+        'not_found': "URL could not be retrieved.",
     }
 
     URL_REGEX = re.compile(r"""^(
@@ -202,7 +202,7 @@ class URLType(StringType):
                 url['path'],
                 url['query'],
                 url['frag'])
-                ).encode('utf-8'), safe='%~:/?#[]@'+sub_delims)
+                ).encode('utf-8'), safe=py_native_string('%~:/?#[]@' + sub_delims))
             try:
                 urlopen(url_string)
             except URLError:
@@ -221,7 +221,7 @@ class EmailType(StringType):
     """
 
     MESSAGES = {
-        'email': u"Not a well-formed email address."
+        'email': "Not a well-formed email address."
     }
 
     EMAIL_REGEX = re.compile(r"""^(

--- a/schematics/types/net.py
+++ b/schematics/types/net.py
@@ -15,17 +15,11 @@ except ImportError: # PY2
     from urlparse import urlunsplit
     from urllib import quote as urlquote
 
-from ..common import *
+from ..common import * # pylint: disable=redefined-builtin
 from ..exceptions import ConversionError, ValidationError, StopValidationError
 from ..util import listify
-from .base import StringType
 
-try:
-    basestring #PY2
-    bytes = str
-except NameError:
-    basestring = str #PY3
-    unicode = str
+from .base import StringType
 
 
 ### Character ranges
@@ -244,4 +238,7 @@ class EmailType(StringType):
     def validate_email(self, value, context=None):
         if not EmailType.EMAIL_REGEX.match(value):
             raise StopValidationError(self.messages['email'])
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -1,5 +1,6 @@
 import copy
 
+from ..common import * # pylint: disable=redefined-builtin
 from ..util import setdefault
 
 from .base import BaseType
@@ -68,4 +69,7 @@ class Serializable(object):
 
     def __deepcopy__(self, memo):
         return self.__class__(self.func, copy.deepcopy(self.type))
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, absolute_import
+
 import copy
 
 from ..common import * # pylint: disable=redefined-builtin
@@ -15,11 +19,11 @@ def serializable(*args, **kwargs):
     ...     country_code = StringType()
     ...     @serializable
     ...     def country_name(self):
-    ...         return {'us': u'United States'}[self.country_code]
+    ...         return {'us': 'United States'}[self.country_code]
     ...
     >>> location = Location({'country_code': 'us'})
     >>> location.serialize()
-    {'country_name': u'United States', 'country_code': u'us'}
+    {'country_name': 'United States', 'country_code': 'us'}
     >>>
     :param type:
         A custom subclass of `BaseType` for enforcing a certain type

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, absolute_import
 
 import collections
 import sys
-import types
 
 from .compat import * # pylint: disable=redefined-builtin
 
@@ -31,6 +30,7 @@ class Constant(int):
 
     def __init__(self, name, value):
         self.name = name
+        int.__init__(self)
 
     def __repr__(self):
         return self.name

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -1,14 +1,10 @@
 from __future__ import absolute_import, division
 
 import collections
+import sys
+import types
 
-try:
-    basestring #PY2
-    bytes = str
-    range = xrange
-except NameError:
-    basestring = str #PY3
-    unicode = str
+from .compat import * # pylint: disable=redefined-builtin
 
 
 def setdefault(obj, attr, value, search_mro=False, overwrite_none=False):
@@ -45,10 +41,23 @@ def listify(value):
         return value
     elif value is None:
         return []
-    elif isinstance(value, basestring):
+    elif isinstance(value, string_type):
         return [value]
     elif isinstance(value, collections.Sequence):
         return list(value)
     else:
         return [value]
+
+
+def module_exports(module_name):
+    module_globals = sys.modules[module_name].__dict__
+    return [
+        name for name, obj in module_globals.items()
+        if name[0] != '_'
+          and (getattr(obj, '__module__', None) == module_name
+                or isinstance(obj, Constant))
+    ]
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import, division
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, absolute_import
 
 import collections
 import sys

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 
+from .common import * # pylint: disable=redefined-builtin
 from .datastructures import Context
 from .exceptions import FieldError, DataError
 from .transforms import import_loop, validation_converter
@@ -104,10 +105,14 @@ def get_validation_context(**options):
 
 def prepare_validator(func, argcount):
     if len(inspect.getargspec(func).args) < argcount:
+        @functools.wraps(func)
         def newfunc(*args, **kwargs):
             if not kwargs or kwargs.pop('context', 0) is 0:
                 args = args[:-1]
             return func(*args, **kwargs)
-        return functools.wraps(func)(newfunc)
+        return newfunc
     return func
+
+
+__all__ = module_exports(__name__)
 

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, absolute_import
+
 import functools
 import inspect
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    install_requires=[
-        'six>=1.7.3',
-    ],
+    install_requires=[],
 )

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -2,8 +2,6 @@ import copy
 import pickle
 
 import pytest
-from six import PY3
-from six.moves import zip
 
 from schematics.datastructures import OrderedDict, DataObject, Context
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from datetime import datetime, timedelta
 import sys
 
@@ -26,6 +28,8 @@ def test_parse_with_defaults():
     dt = field.to_native('2015-11-08T12:34:56,0369-0730')
     assert dt.utcoffset() == timedelta(hours=-7, minutes=-30)
     assert dt.replace(tzinfo=None) == datetime(2015, 11, 8, 12, 34, 56, 36900)
+
+    assert dt == field.to_native(u'2015-11-08T12:34:56,0369−0730') # minus U+2212
 
     dt = field.to_native('2015-11-08 12:34:56.00200+02:00')
     assert dt.utcoffset() == timedelta(hours=2)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -41,36 +41,36 @@ def test_error_from_mixed_args():
 
     e = ValidationError(
             ('hello', 99),
-            ('world', 98),
+            'world',
             ErrorMessage('from_msg', info=0),
             ValidationError('from_err', info=1))
 
     assert e == e.messages == ['hello', 'world', 'from_msg', 'from_err']
-    assert [msg.info for msg in e] == [99, 98, 0, 1]
+    assert [msg.info for msg in e] == [99, None, 0, 1]
 
 
 def test_error_from_mixed_list():
 
     e = ConversionError([
             ('hello', 99),
-            ('world', 98),
+            'world',
             ErrorMessage('from_msg', info=0),
             ConversionError('from_err', info=1)])
 
     assert e.messages == ['hello', 'world', 'from_msg', 'from_err']
-    assert [msg.info for msg in e.messages] == [99, 98, 0, 1]
+    assert [msg.info for msg in e.messages] == [99, None, 0, 1]
 
 
 def test_error_repr():
 
-    assert str(ValidationError('foo')) == 'ValidationError("foo", info=None)'
+    assert str(ValidationError('foo')) == 'ValidationError("foo")'
 
     e = ValidationError(
             ('foo', None),
             ('bar', 98),
             ('baz', [1, 2, 3]))
 
-    assert str(e) == 'ValidationError(("foo", None), ("bar", 98), ("baz", <\'list\' object>))'
+    assert str(e) == 'ValidationError(["foo", ("bar", 98), ("baz", <\'list\' object>)])'
 
     e = ValidationError(u'é')
     assert str(e) == repr(e)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
 from schematics.exceptions import *
@@ -69,6 +71,9 @@ def test_error_repr():
             ('baz', [1, 2, 3]))
 
     assert str(e) == 'ValidationError(("foo", None), ("bar", 98), ("baz", <\'list\' object>))'
+
+    e = ValidationError(u'é')
+    assert str(e) == repr(e)
 
 
 def test_error_message_object():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import datetime
 import pytest
+import uuid
 
 from schematics.common import *
 from schematics.models import Model

--- a/tests/test_model_type.py
+++ b/tests/test_model_type.py
@@ -14,9 +14,6 @@ def test_simple_embedded_models():
         id = IntType()
         location = ModelType(Location)
 
-    r = repr(Player.location)
-    assert r.startswith("<schematics.types.compound.ModelType object at 0x")
-
     p = Player(dict(id=1, location={"country_code": "US"}))
 
     assert p.id == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+
 import pytest
 
 from schematics.models import Model, ModelOptions
 from schematics.transforms import whitelist, blacklist
 from schematics.undefined import Undefined
 
+from schematics.common import PY2
 from schematics.types.base import StringType, IntType
 from schematics.types.compound import ModelType
 from schematics.exceptions import *
@@ -603,5 +605,18 @@ def test_eq():
 
 def test_repr():
     inst = SimpleModel({'field1': 'foo'})
-    assert repr(inst) == '<SimpleModel: SimpleModel object>'
+    assert repr(inst) == str(inst) == '<SimpleModel instance>'
+
+    class FooModel(SimpleModel):
+        def _repr_info(self):
+            return str.join(', ', (self[k] for k in self))
+
+    inst = FooModel({'field1': 'foo', 'field2': 'bar'})
+    assert repr(inst) == '<FooModel: foo, bar>'
+
+    inst = FooModel({'field1': u'é', 'field2': u'Ä'})
+    if PY2:
+        assert repr(inst) == '<FooModel: \\xe9, \\xc4>'
+    else:
+        assert repr(inst) == '<FooModel: é, Ä>'
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,8 +9,6 @@ from schematics.types.base import StringType, IntType
 from schematics.types.compound import ModelType
 from schematics.exceptions import *
 
-from six import PY3
-
 
 def test_init_with_dict():
 
@@ -606,8 +604,4 @@ def test_eq():
 def test_repr():
     inst = SimpleModel({'field1': 'foo'})
     assert repr(inst) == '<SimpleModel: SimpleModel object>'
-
-    if not PY3: #todo: make this work for PY3
-        inst.__class__.__name__ = '\x80'
-        assert repr(inst) == '<[Bad Unicode class name]: [Bad Unicode data]>'
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -8,13 +8,6 @@ from schematics.types.compound import ModelType, DictType, ListType
 from schematics.types.serializable import serializable
 from schematics.transforms import blacklist, whitelist, wholelist, export_loop
 
-import six
-from six import iteritems
-try:
-    unicode #PY2
-except:
-    import codecs
-    unicode = str #PY3
 
 def test_serializable():
     class Location(Model):
@@ -79,7 +72,7 @@ def test_serializable_with_custom_serializable_class():
     class PlayerIdType(LongType):
 
         def to_primitive(self, value, context=None):
-            return unicode(value)
+            return str(value)
 
     class Player(Model):
         id = LongType()
@@ -761,7 +754,7 @@ def test_role_set_operations():
             n += 1
 
     class User(Model):
-        id = IntType(default=six.next(count(42)))
+        id = IntType(default=next(count(42)))
         name = StringType()
         email = StringType()
         password = StringType()
@@ -802,7 +795,7 @@ def test_role_set_operations():
 
     user = User(
         dict(
-            (k, v) for k, v in iteritems(data)
+            (k, v) for k, v in data.items()
             if k in User._options.roles['create']  # filter by 'create' role
         )
     )

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,11 +12,29 @@ import pytest
 from schematics.datastructures import Context
 from schematics.models import Model
 from schematics.types import *
+from schematics.types.compound import *
 from schematics.types.base import get_range_endpoints
 from schematics.exceptions import ConversionError, ValidationError, DataError
 
 
 _uuid = uuid.UUID('3ce85e48-3028-409c-a07c-c8ee3d16d5c4')
+
+
+def test_type_repr():
+
+    class Bar(Model):
+        pass
+
+    class Foo(Model):
+        intfield = IntType()
+        modelfield = ModelType(Bar)
+        listfield = ListType(ListType(StringType))
+
+    assert repr(Foo.intfield) == "<IntType() instance on Foo as 'intfield'>"
+    assert repr(Foo.listfield) == "<ListType(ListType) instance on Foo as 'listfield'>"
+    assert repr(Foo.listfield.field.field) == "<StringType() instance on Foo>"
+    assert repr(Foo.modelfield) == "<ModelType(Bar) instance on Foo as 'modelfield'>"
+    assert repr(DateTimeType()) == "<DateTimeType() instance>"
 
 
 def test_string_choices():

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,8 @@ deps = -r{toxinidir}/test-requirements.txt
 
 [pytest]
 addopts = tests
-pep8maxlinelength = 120
+pep8maxlinelength = 115
+
+[flake8]
+max-line-length = 115
+ignore = E203, E221, E261, W391


### PR DESCRIPTION
This set of commits standardizes on Python 3 style and replaces ad-hoc compatibility maneuvers with a shared compatibility module `compat`. It is deployed to all modules via `from .common import *`.

Changes to string handling:
* `str` now produces Unicode strings; `unicode` is obsolete.
* `unicode_literals` is now enabled; `u`-prefixes are obsolete.

On Python 2, the `__str__()` and `__repr__()` methods on `Model` and `FieldError` are patched to transparently encode non-ASCII code points.

All modules now declare `__all__` to prevent globals from leaking on `from <> import *`.

The `six` dependency is gone.

