### PR TITLE
Expose compound types to `schematics.types` interface

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -15,7 +15,7 @@ from .transforms import (
     flatten, expand
 )
 from .validate import validate, prepare_validator
-from .types import BaseType
+from .types.base import BaseType
 from .types.serializable import Serializable
 from .undefined import Undefined
 

--- a/schematics/types/__init__.py
+++ b/schematics/types/__init__.py
@@ -1,4 +1,5 @@
 from .base import *
 from .net import *
+from .compound import *
 
 __all__ = [name for name, obj in globals().items() if isinstance(obj, TypeMeta)]

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -9,7 +9,6 @@ import itertools
 from ..common import * # pylint: disable=redefined-builtin
 from ..datastructures import OrderedDict
 from ..exceptions import *
-from ..models import Model, ModelMeta
 from ..transforms import (
     get_import_context, get_export_context,
     to_native_converter, to_dict_converter, to_primitive_converter)
@@ -89,6 +88,7 @@ class ModelType(CompoundType):
         return self.model_class.fields
 
     def __init__(self, model_spec, **kwargs):
+        from ..models import ModelMeta
 
         if isinstance(model_spec, ModelMeta):
             self.model_class = model_spec
@@ -118,8 +118,8 @@ class ModelType(CompoundType):
         super(ModelType, self)._setup(field_name, owner_model)
 
     def pre_setattr(self, value):
-        if value is not None \
-          and not isinstance(value, Model):
+        from ..models import Model
+        if value is not None and not isinstance(value, Model):
             value = self.model_class(value)
         return value
 
@@ -306,6 +306,7 @@ class PolyModelType(CompoundType):
     """A field that accepts an instance of any of the specified models."""
 
     def __init__(self, model_spec, **kwargs):
+        from ..models import ModelMeta
 
         if isinstance(model_spec, (ModelMeta, string_type)):
             self.model_classes = (model_spec,)


### PR DESCRIPTION
Small change; just noticed that you can't reference `types.DictType` when doing `from schemata import types`, which is a bummer.