### PR TITLE
Change conversion rules for booleans

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -382,6 +382,8 @@ class StringType(BaseType):
                     return str(value, 'utf-8')
                 except UnicodeError:
                     raise ConversionError(self.messages['decode'].format(value))
+            elif isinstance(value, bool):
+                pass
             else:
                 return str(value)
         raise ConversionError(self.messages['convert'].format(value))
@@ -424,6 +426,8 @@ class NumberType(BaseType):
         return get_value_in(self.min_value, self.max_value)
 
     def to_native(self, value, context=None):
+        if isinstance(value, bool):
+            value = int(value)
         if isinstance(value, self.number_class):
             return value
         try:


### PR DESCRIPTION
- `StringType` will reject `bool`.
- `IntType` will upcast `bool` to `int`.

***

The fact that the Python `bool` is a subclass of `int` is more a historical accident than a well-founded principle of the type system. Fundamentally, booleans have nothing to do with integers. Therefore I believe special-casing `bool` is entirely warranted.

Resolves #315.
