### PR TITLE
RFC: Validate should either pass self or discover class methods

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -243,6 +243,18 @@ def test_validate_methods_passed_self():
     Foo({'foo': u'Bar'}).validate()
 
 
+def test_validate_discovers_classmethod():
+    class Foo(Model):
+        foo = StringType()
+
+        @classmethod
+        def validate_foo(cls, data, value, context):
+            raise ValidationError(u"I'm a classmethod that should be discovered.")
+
+    with pytest.raises(DataError):
+        Foo({'foo': u'Bar'}).validate()
+
+
 def test_basic_error():
     class School(Model):
         name = StringType(required=True)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -233,6 +233,15 @@ def test_multi_key_validation_fields_order():
         Signup({'name': u'Brad'}).validate()
 
 
+def test_validate_methods_passed_self():
+    class Foo(Model):
+        foo = StringType()
+
+        def validate_foo(self, data, value, context):
+            assert self.__class__.__name__ == 'Foo'
+
+    Foo({'foo': u'Bar'}).validate()
+
 
 def test_basic_error():
     class School(Model):


### PR DESCRIPTION
As [outlined in the docs](https://github.com/schematics/schematics/blame/development/docs/usage/validation.rst#L125), a custom `validate_*` method receives `self`.

However this isn't actually the case, it receives the class (as tested in `test_validate_methods_passed_self`).

This would only be a documentation issue if methods decorated with `@classmethod` where actually discovered, but they aren't, as proven in my test `test_validate_discovers_classmethod`.

In order to fix this, which direction should be taken?

After looking the code I would think the intention is that `validate_*` methods should be decorated with `@classmethod` and be discoverable (as `self` is relatively useless, and potentially "dangerous", if being called within an `__init__`)