### PR TITLE
RFC: Compound type values shared across instances when default supplied

### DIFF
--- a/tests/test_dict_type.py
+++ b/tests/test_dict_type.py
@@ -159,3 +159,16 @@ def test_key_type():
     assert d == {
         "categories": {1: {"slug": "math"}}
     }
+
+
+def test_dict_default_not_shared():
+    class Foo(Model):
+        foo = DictType(IntType, default=dict())
+
+    one = Foo()
+    one.foo['a'] = 3
+
+    two = Foo()
+
+    assert one.foo['a'] == 3
+    assert 'a' not in two.foo

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -236,3 +236,15 @@ def test_mock_object_with_model_type():
         age = IntType(required=True)
 
     assert isinstance(ListType(ModelType(User), required=True).mock()[-1], User)
+
+
+def test_list_default_not_shared():
+    class Foo(Model):
+        foo = ListType(IntType, default=[])
+
+    one = Foo()
+    one.foo.append(1)
+
+    two = Foo()
+    assert len(one.foo) == 1
+    assert len(two.foo) == 0


### PR DESCRIPTION
It appears that if a default is supplied to either `DictType` or `ListType` then the value on an actual model instance is shared across instances.

Is this the intention?