### PR TITLE
Restore v1 to_native behavior; simplify converter code

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -11,7 +11,7 @@ from .datastructures import OrderedDict, Context
 from .exceptions import *
 from .transforms import (
     atoms, export_loop,
-    convert, to_native, to_dict, to_primitive,
+    convert, to_native, to_primitive,
 )
 from .validate import validate, prepare_validator
 from .types import BaseType
@@ -297,9 +297,6 @@ class Model(object):
 
     def to_native(self, role=None, app_data=None, **kwargs):
         return to_native(self.__class__, self, role=role, app_data=app_data, **kwargs)
-
-    def to_dict(self, role=None, app_data=None, **kwargs):
-        return to_dict(self.__class__, self, role=role, app_data=app_data, **kwargs)
 
     def to_primitive(self, role=None, app_data=None, **kwargs):
         return to_primitive(self.__class__, self, role=role, app_data=app_data, **kwargs)

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -437,7 +437,7 @@ def blacklist(*field_list):
 ###
 
 
-class FieldConverter(object):
+class Converter(object):
 
     def __call__(self, field, value, context):
         raise NotImplementedError
@@ -449,7 +449,7 @@ class FieldConverter(object):
         return data
 
 
-class BasicConverter(FieldConverter):
+class BasicConverter(Converter):
 
     def __init__(self, func):
         self.func = func
@@ -464,33 +464,14 @@ class BasicConverter(FieldConverter):
 ###
 
 
-class ExportConverter(FieldConverter):
-
-    def __init__(self, format, exceptions=None):
-        self.primary = format
-        self.secondary = not format
-        self.exceptions = set(exceptions) if exceptions else None
-
-    def __call__(self, field, value, context):
-        format = self.primary
-        if self.exceptions:
-            if any((issubclass(field.typeclass, cls) for cls in self.exceptions)):
-                format = self.secondary
-        return field.export(value, format, context)
+@BasicConverter
+def to_native_converter(field, value, context):
+    return field.export(value, NATIVE, context)
 
 
-class NativeConverter(ExportConverter):
-
-    def __init__(self, exceptions=None):
-        ExportConverter.__init__(self, NATIVE, exceptions)
-
-    def post(self, model_class, data, context):
-        return model_class(data, init=False)
-
-
-to_native_converter = NativeConverter()
-to_dict_converter = ExportConverter(NATIVE)
-to_primitive_converter = ExportConverter(PRIMITIVE)
+@BasicConverter
+def to_primitive_converter(field, value, context):
+    return field.export(value, PRIMITIVE, context)
 
 
 
@@ -499,27 +480,20 @@ to_primitive_converter = ExportConverter(PRIMITIVE)
 ###
 
 
-class ImportConverter(FieldConverter):
-
-    def __init__(self, action):
-        self.action = action
-        self.method = operator.attrgetter(self.action)
-
-    def __call__(self, field, value, context):
-        field.check_required(value, context)
-        if value in (None, Undefined):
-            return value
-        return self.method(field)(value, context)
-
-    def pre(self, model_class, instance_or_dict, context):
-        return instance_or_dict
-
-    def post(self, model_class, data, context):
-        return data
+@BasicConverter
+def import_converter(field, value, context):
+    field.check_required(value, context)
+    if value in (None, Undefined):
+        return value
+    return field.convert(value, context)
 
 
-import_converter = ImportConverter('convert')
-validation_converter = ImportConverter('validate')
+@BasicConverter
+def validation_converter(field, value, context):
+    field.check_required(value, context)
+    if value in (None, Undefined):
+        return value
+    return field.validate(value, context)
 
 
 
@@ -563,10 +537,6 @@ def convert(cls, instance_or_dict, **kwargs):
 
 def to_native(cls, instance_or_dict, **kwargs):
     return export_loop(cls, instance_or_dict, to_native_converter, **kwargs)
-
-
-def to_dict(cls, instance_or_dict, **kwargs):
-    return export_loop(cls, instance_or_dict, to_dict_converter, **kwargs)
 
 
 def to_primitive(cls, instance_or_dict, **kwargs):

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -12,7 +12,7 @@ from ..exceptions import *
 from ..transforms import (
     export_loop,
     get_import_context, get_export_context,
-    to_native_converter, to_dict_converter, to_primitive_converter)
+    to_native_converter, to_primitive_converter)
 
 from .base import BaseType, get_value_in
 
@@ -50,10 +50,6 @@ class CompoundType(BaseType):
     def to_native(self, value, context=None):
         context = context or get_export_context(to_native_converter)
         return to_native_converter(self, value, context)
-
-    def to_dict(self, value, context=None):
-        context = context or get_export_context(to_dict_converter)
-        return to_dict_converter(self, value, context)
 
     def to_primitive(self, value, context=None):
         context = context or get_export_context(to_primitive_converter)

--- a/tests/test_export_level.py
+++ b/tests/test_export_level.py
@@ -4,7 +4,6 @@ import pytest
 
 from schematics.common import *
 from schematics.models import Model
-from schematics.transforms import ExportConverter
 from schematics.types import *
 from schematics.types.compound import *
 from schematics.types.serializable import serializable

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,7 +4,6 @@ import pytest
 
 from schematics.common import *
 from schematics.models import Model
-from schematics.transforms import ExportConverter
 from schematics.types import *
 from schematics.types.compound import *
 from schematics.types.serializable import serializable

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -24,7 +24,7 @@ def test_serializable():
     d = location_US.serialize()
     assert d == {"country_code": "US", "country_name": "United States"}
 
-    d = location_US.to_dict()
+    d = location_US.to_native()
     assert d == {"country_code": u"US", "country_name": "United States"}
 
     location_IS = Location({"country_code": "IS"})
@@ -34,11 +34,11 @@ def test_serializable():
     d = location_IS.serialize()
     assert d == {"country_code": "IS", "country_name": "Unknown"}
 
-    d = location_IS.to_dict()
+    d = location_IS.to_native()
     assert d == {"country_code": "IS", "country_name": "Unknown"}
 
 
-def test_serializable_to_dict():
+def test_serializable_to_native():
     class Location(Model):
         country_code = StringType()
 
@@ -48,7 +48,7 @@ def test_serializable_to_dict():
 
     loc = Location({'country_code': 'US'})
 
-    d = loc.to_dict()
+    d = loc.to_native()
     assert d == {'country_code': 'US', 'country_name': 'United States'}
 
 
@@ -110,7 +110,7 @@ def test_serializable_with_model():
     assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
 
 
-def test_serializable_with_model_to_dict():
+def test_serializable_with_model_to_native():
     class ExperienceLevel(Model):
         level = IntType()
         title = StringType()
@@ -126,7 +126,7 @@ def test_serializable_with_model_to_dict():
 
     assert player.xp_level.level == 4
 
-    d = player.to_dict()
+    d = player.to_native()
     assert d == {"total_points": 2, "xp_level": {"level": 4, "title": "Best"}}
 
 


### PR DESCRIPTION
Summary:

* `to_native()` on export now produces a dictionary again.
* The bundled converters are written as plain functions to make the code easier to understand.

Resolves #405.
