### PR TITLE
Allow passing a callable to `choices`

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -167,7 +167,7 @@ class BaseType(object):
         self._default = default
         self.serialized_name = serialized_name
         if choices and not (callable(choices) or isinstance(choices, (list, tuple))):
-            raise TypeError('"choices" must be a list or tuple')
+            raise TypeError('"choices" must be a callabe, list, or tuple')
         self._choices = choices
         self.deserialize_from = listify(deserialize_from)
 
@@ -266,7 +266,7 @@ class BaseType(object):
         if callable(choices):
             choices = choices()
             if not isinstance(choices, (list, tuple)):
-                raise TypeError('"choices" must be a list or tuple')
+                raise TypeError('"choices" callable must return a list or tuple')
         return choices
 
     def pre_setattr(self, value):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -241,6 +241,15 @@ def test_field_default():
     assert u.name == u'Doggy'
 
 
+def test_field_default_callable():
+    class User(Model):
+        name = StringType(default=lambda: u'Doggy')
+
+    u = User()
+    assert User.name.__class__ == StringType
+    assert u.name == u'Doggy'
+
+
 def test_attribute_default_to_none_if_no_value():
     class User(Model):
         name = StringType()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,6 +22,14 @@ def test_choices_validates():
     doc.validate()
 
 
+def test_choices_callable_validates():
+    class Document(Model):
+        language = StringType(choices=lambda: ['en', 'de'])
+
+    doc = Document({'language': 'de'})
+    doc.validate()
+
+
 def test_validation_fails():
     class Document(Model):
         language = StringType(choices=['en', 'de'])


### PR DESCRIPTION
As a developer I want the ability to avoid generating the list of choices for a type during class definition (which is usually at module scope) as doing so for all models might be expensive.  This pull request makes `choices` behave like `default`.  As with `default`, users should take care to do their own caching of choices if the computation of these values is expensive.
