### PR TITLE
When testing if a values is None or Undefined, use 'is'.

### DIFF
--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -239,7 +239,7 @@ def export_loop(cls, instance_or_dict, field_converter=None, role=None, raise_er
         if _export_level == DROP:
             continue
 
-        elif value not in (None, Undefined):
+        elif value is not None and value is not Undefined:
             value = _field_converter(field, value, context)
 
         if value is Undefined:
@@ -482,7 +482,7 @@ def to_primitive_converter(field, value, context):
 @BasicConverter
 def import_converter(field, value, context):
     field.check_required(value, context)
-    if value in (None, Undefined):
+    if value is None or value is Undefined:
         return value
     return field.convert(value, context)
 
@@ -490,7 +490,7 @@ def import_converter(field, value, context):
 @BasicConverter
 def validation_converter(field, value, context):
     field.check_required(value, context)
-    if value in (None, Undefined):
+    if value is None or value is Undefined:
         return value
     return field.validate(value, context)
 

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -309,7 +309,7 @@ class BaseType(object):
         return value
 
     def check_required(self, value, context):
-        if self.required and value in (None, Undefined):
+        if self.required and (value is None or value is Undefined):
             if self.name is None or context and not context.partial:
                 raise ConversionError(self.messages['required'])
 


### PR DESCRIPTION
`value in (None, Undefined)` invokes `value.__eq__`, which may have side effects.