### PR TITLE
Allow primitive and native types to be inspected

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -438,14 +438,14 @@ class NumberType(BaseType):
     def to_native(self, value, context=None):
         if isinstance(value, bool):
             value = int(value)
-        if isinstance(value, self.primitive_type):
+        if isinstance(value, self.native_type):
             return value
         try:
-            native_value = self.primitive_type(value)
+            native_value = self.native_type(value)
         except (TypeError, ValueError):
             pass
         else:
-            if self.primitive_type is float: # Float conversion is strict enough.
+            if self.native_type is float: # Float conversion is strict enough.
                 return native_value
             if not self.strict and native_value == value: # Match numeric types.
                 return native_value

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -75,6 +75,12 @@ MultiType = CompoundType
 class ModelType(CompoundType):
     """A field that can hold an instance of the specified model."""
 
+    primitive_type = dict
+
+    @property
+    def native_type(self):
+        return self.model_class
+
     @property
     def fields(self):
         return self.model_class.fields
@@ -145,6 +151,9 @@ class ListType(CompoundType):
         ...
         categories = ListType(StringType)
     """
+
+    primitive_type = list
+    native_type = list
 
     def __init__(self, field, min_size=None, max_size=None, **kwargs):
         self.field = self._init_field(field, kwargs)
@@ -245,6 +254,9 @@ class DictType(CompoundType):
 
     """
 
+    primitive_type = dict
+    native_type = dict
+
     def __init__(self, field, coerce_key=None, **kwargs):
         self.field = self._init_field(field, kwargs)
         self.coerce_key = coerce_key or str
@@ -295,6 +307,9 @@ class DictType(CompoundType):
 
 class PolyModelType(CompoundType):
     """A field that accepts an instance of any of the specified models."""
+
+    primitive_type = dict
+    native_type = None  # cannot be determined from a PolyModelType instance
 
     def __init__(self, model_spec, **kwargs):
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -199,12 +199,12 @@ def test_timestamp():
     field_no_tz = TimestampType(drop_tzinfo=True)
 
     ts = field.to_primitive(datetime(2015, 11, 8, 14, 00))
-    assert ts == 1446991200
-    assert type(ts) == int
+    assert ts == 1446991200.0
+    assert type(ts) == float
 
     ts = field_no_tz.to_primitive(datetime(2015, 11, 8, 14, 00))
-    assert ts == 1446991200
-    assert type(ts) == int
+    assert ts == 1446991200.0
+    assert type(ts) == float
 
     ts = field.to_primitive(datetime(2014, 5, 8, 22, 40, 40, tzinfo=gettz('PST8PDT')))
     assert ts == 1399614040.0


### PR DESCRIPTION
This is a first pass at the feature discussed in issue #429

Some notes:
- instance variable `NumberType.number_class` has been replaced with class variable `NumberType.native_type`
- as discussed, `PolyModelType.native_type` is None because it can't be known
- as discussed, `TimestampType` always converts to float
- made a slight adjustment to ensure that `GeoPointType` always converts to `list`

Regarding `GeoPointType`, it might be nice for it to be a compound type, so that the data type of its components (`int`) can be inspected.  Also, it's a good demonstration of how schematics is meant to work.

I'm sure there will be some feedback, so let me know.
