### PR TITLE
Support for raising DataError inside custom validate_fieldname methods.

### DIFF
--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -80,10 +80,10 @@ def _validate_model(cls, data, context):
             value = data[field_name]
             try:
                 cls._validator_functions[field_name](cls, data, value, context)
-            except FieldError as exc:
+            except (DataError, FieldError) as exc:
                 field = cls._fields[field_name]
                 serialized_field_name = field.serialized_name or field_name
-                errors[serialized_field_name] = exc.messages
+                errors[serialized_field_name] = exc.messages if isinstance(exc, FieldError) else exc.errors
                 invalid_fields.append(field_name)
 
     for field_name in invalid_fields:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -387,6 +387,51 @@ def test_deep_errors_with_dicts():
     }
 
 
+def test_custom_validator_raising_dicterror():
+    class Foo(Model):
+        bar = DictType(IntType(required=True), required=True)
+        eggs = IntType(required=True, min_value=10)
+
+        @classmethod
+        def validate_bar(cls, data, value):
+            errors = {}
+
+            if 'a' not in value:
+                errors['a'] = ValidationError('Key a must be set.')
+            if 'b' not in value:
+                errors['b'] = ValidationError('Key b must be set.')
+
+            if errors:
+                raise DataError(errors)
+
+    valid_data = {
+        'bar': {
+            'a': 1,
+            'b': 1,
+        },
+        'eggs': 10
+    }
+    foo = Foo(valid_data)
+    foo.validate()
+
+    invalid_data = foo.serialize()
+    del invalid_data['bar']['a']
+    invalid_data['eggs'] = 1
+
+    foo = Foo(invalid_data)
+    with pytest.raises(DataError) as exception:
+        foo.validate()
+
+    messages = exception.value.messages
+
+    assert messages == {
+        'bar': {
+            'a': [u'Key a must be set.']
+        },
+        'eggs': [u'Int value should be greater than or equal to 10.']
+    }
+
+
 def test_type_validator_inheritance():
 
     class CustomIntType(IntType):


### PR DESCRIPTION
I'd really like to be able to raise DataError from within a `validate_fieldname` method so that for a compound type it can provide a more detailed error message.

For instance;

``` python
class A(Model):
    foo = DictType(StringType(required=True, min_length=1), required=True)
    bar = IntType(required=True, min_value=10)

    @classmethod
    def validate_foo(cls, data, value):
        errors = {}

        if 'key1' not in value:
            errors['key1'] = ValidationError('key1 not present')

        if 'key2' not in value:
            errors['key2'] = ValidationError('key2 not present')

        if errors:
            raise DataError(errors=errors)


A(
    raw_data=dict(
        foo=dict(key2="I will validate but foo won't as key1 is missing."),
        bar=1
    ),
    validate=True
)
```

Ideally what I'd expect from the above is that the following error structure is raised;

``` python
{
    'foo': {
        'key1': ValidationError("key1 not present")
    },
    'bar': ValidationError("Int value should be greater than or equal to 10.")
}
```

However, of course at the moment what actually is raised is just the `DataError` as per the `validate_foo` method.

Of course my example is pretty trivial and could be better done with two fields on the model etc... however in my actual use case this is not possible (and certainly not trivial hence why I haven't included it).
