### PR TITLE
Schema API

### DIFF
--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -2,6 +2,10 @@
 
 __version__ = '2.0.0.a1'
 
+# TODO: remove deprecated API
+from . import deprecated
+deprecated.patch_all()
+
 from .models import Model, ModelMeta
 
 types.compound.Model = Model

--- a/schematics/__init__.py
+++ b/schematics/__init__.py
@@ -6,6 +6,7 @@ __version__ = '2.0.0.a1'
 from . import deprecated
 deprecated.patch_all()
 
+from . import types
 from .models import Model, ModelMeta
 
 types.compound.Model = Model

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -31,8 +31,9 @@ else:
 def metaclass(metaclass):
     def make_class(cls):
         attrs = cls.__dict__.copy()
-        del attrs['__dict__']
-        del attrs['__weakref__']
+        if attrs.get('__dict__'):
+            del attrs['__dict__']
+            del attrs['__weakref__']
         return metaclass(cls.__name__, cls.__bases__, attrs)
     return make_class
 

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -23,9 +23,11 @@ if PY2:
     from itertools import imap as map
     from itertools import izip as zip
     iteritems = operator.methodcaller('iteritems')
+    itervalues = operator.methodcaller('itervalues')
 else:
     string_type = str
     iteritems = operator.methodcaller('items')
+    itervalues = operator.methodcaller('values')
 
 
 def metaclass(metaclass):

--- a/schematics/contrib/machine.py
+++ b/schematics/contrib/machine.py
@@ -10,7 +10,7 @@ def _callback_wrap(data, schema, func, *args, **kwargs):
 
 
 class Machine(object):
-    """ A poor mans state machine. """
+    """ A poor man's state machine. """
 
     states = ('raw', 'converted', 'validated', 'serialized')
     transitions = (

--- a/schematics/contrib/machine.py
+++ b/schematics/contrib/machine.py
@@ -1,0 +1,64 @@
+
+from ..transforms import convert, to_primitive
+from ..validate import validate
+
+import functools
+
+
+def _callback_wrap(data, schema, func, *args, **kwargs):
+    return func(schema, data, *args, **kwargs)
+
+
+class Machine(object):
+    """ A poor mans state machine. """
+
+    states = ('raw', 'converted', 'validated', 'serialized')
+    transitions = (
+        {'trigger': 'init', 'to': 'raw'},
+        {'trigger': 'convert', 'from': 'raw', 'to': 'converted'},
+        {'trigger': 'validate', 'from': 'converted', 'to': 'validated'},
+        {'trigger': 'serialize', 'from': 'validated', 'to': 'serialized'}
+    )
+    callbacks = {
+        'convert': functools.partial(_callback_wrap, func=convert, partial=True),
+        'validate': functools.partial(_callback_wrap, func=validate, convert=False, partial=False),
+        'serialize': functools.partial(_callback_wrap, func=to_primitive)
+    }
+
+    def __init__(self, data, *args):
+        self.state = self._transition(trigger='init')['to']
+        self.data = data
+        self.args = args
+
+    def __getattr__(self, name):
+        return functools.partial(self.trigger, name)
+
+    def _transition(self, trigger=None, src_state=None, dst_state=None):
+        try:
+            return next(self._transitions(trigger=trigger, src_state=src_state,
+            dst_state=dst_state))
+        except StopIteration:
+            return None
+
+    def _transitions(self, trigger=None, src_state=None, dst_state=None):
+        def pred(d, key, var):
+            return d.get(key) == var if var is not None else True
+        return (d for d in self.transitions if
+            pred(d, 'trigger', trigger) and
+            pred(d, 'from', src_state) and
+            pred(d, 'to', dst_state)
+        )
+
+    def trigger(self, trigger):
+        transition = self._transition(trigger=trigger, src_state=self.state)
+        if not transition:
+            raise AttributeError(trigger)
+        callback = self.callbacks.get(trigger)
+        self.data = callback(self.data, *self.args) if callback else self.data
+        self.state = transition['to']
+
+    def can(self, state):
+        return bool(self._transition(src_state=self.state, dst_state=state))
+
+    def cannot(self, state):
+        return not self.can(state)

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -315,6 +315,134 @@ class Context(DataObject):
     __nonzero__ = __bool__
 
 
+try:
+    from collections import ChainMap
+except ImportError:
+    """ Code extracted from CPython 3 stdlib:
+    https://github.com/python/cpython/blob/85f2c89ee8223590ba08e3aea97476f76c7e3734/Lib/collections/__init__.py#L852
+
+    """
+    from collections import MutableMapping
+
+    class ChainMap(MutableMapping):
+        ''' A ChainMap groups multiple dicts (or other mappings) together
+        to create a single, updateable view.
+        The underlying mappings are stored in a list.  That list is public and can
+        be accessed or updated using the *maps* attribute.  There is no other
+        state.
+        Lookups search the underlying mappings successively until a key is found.
+        In contrast, writes, updates, and deletions only operate on the first
+        mapping.
+        '''
+
+        def __init__(self, *maps):
+            '''Initialize a ChainMap by setting *maps* to the given mappings.
+            If no mappings are provided, a single empty dictionary is used.
+            '''
+            self.maps = list(maps) or [{}]          # always at least one map
+
+        def __missing__(self, key):
+            raise KeyError(key)
+
+        def __getitem__(self, key):
+            for mapping in self.maps:
+                try:
+                    return mapping[key]             # can't use 'key in mapping' with defaultdict
+                except KeyError:
+                    pass
+            return self.__missing__(key)            # support subclasses that define __missing__
+
+        def get(self, key, default=None):
+            return self[key] if key in self else default
+
+        def __len__(self):
+            return len(set().union(*self.maps))     # reuses stored hash values if possible
+
+        def __iter__(self):
+            return iter(set().union(*self.maps))
+
+        def __contains__(self, key):
+            return any(key in m for m in self.maps)
+
+        def __bool__(self):
+            return any(self.maps)
+
+        # @_recursive_repr()
+        def __repr__(self):
+            return '{0.__class__.__name__}({1})'.format(
+                self, ', '.join(map(repr, self.maps)))
+
+        @classmethod
+        def fromkeys(cls, iterable, *args):
+            'Create a ChainMap with a single dict created from the iterable.'
+            return cls(dict.fromkeys(iterable, *args))
+
+        def copy(self):
+            'New ChainMap or subclass with a new copy of maps[0] and refs to maps[1:]'
+            return self.__class__(self.maps[0].copy(), *self.maps[1:])
+
+        __copy__ = copy
+
+        def new_child(self, m=None):                # like Django's Context.push()
+            '''New ChainMap with a new map followed by all previous maps.
+            If no map is provided, an empty dict is used.
+            '''
+            if m is None:
+                m = {}
+            return self.__class__(m, *self.maps)
+
+        @property
+        def parents(self):                          # like Django's Context.pop()
+            'New ChainMap from maps[1:].'
+            return self.__class__(*self.maps[1:])
+
+        def __setitem__(self, key, value):
+            self.maps[0][key] = value
+
+        def __delitem__(self, key):
+            try:
+                del self.maps[0][key]
+            except KeyError:
+                raise KeyError('Key not found in the first mapping: {!r}'.format(key))
+
+        def popitem(self):
+            'Remove and return an item pair from maps[0]. Raise KeyError is maps[0] is empty.'
+            try:
+                return self.maps[0].popitem()
+            except KeyError:
+                raise KeyError('No keys found in the first mapping.')
+
+        def pop(self, key, *args):
+            'Remove *key* from maps[0] and return its value. Raise KeyError if *key* not in maps[0].'
+            try:
+                return self.maps[0].pop(key, *args)
+            except KeyError:
+                raise KeyError('Key not found in the first mapping: {!r}'.format(key))
+
+        def clear(self):
+            'Clear maps[0], leaving maps[1:] intact.'
+            self.maps[0].clear()
+
+try:
+    from types import MappingProxyType
+except ImportError:
+    from collections import Mapping
+
+    class MappingProxyType(Mapping):
+        def __init__(self, map):
+            self._map = map
+
+        def __len__(self):
+            return len(self._map)
+
+        def __iter__(self):
+            return iter(self._map)
+
+        def __getitem__(self, key):
+            return self._map[key]
+
+        def __repr__(self):
+            return '{0.__class__.__name__}({1})'.format(self, self._map)
+
 
 __all__ = module_exports(__name__)
-

--- a/schematics/deprecated.py
+++ b/schematics/deprecated.py
@@ -2,7 +2,7 @@
 from .compat import iteritems
 from .datastructures import OrderedDict
 from .types.serializable import Serializable
-import transforms
+from . import transforms
 
 import warnings
 import functools

--- a/schematics/deprecated.py
+++ b/schematics/deprecated.py
@@ -2,6 +2,7 @@
 from .compat import iteritems
 from .datastructures import OrderedDict
 from .types.serializable import Serializable
+import transforms
 
 import warnings
 import functools
@@ -97,6 +98,12 @@ class ModelCompatibilityMixin(object):
     @deprecated
     def _validator_functions(cls):
         return cls._schema.validators
+
+    @classmethod
+    @deprecated
+    def convert(cls, raw_data, context=None, **kw):
+        return transforms.convert(cls._schema, raw_data, oo=True,
+            context=context, **kw)
 
 
 def patch_models():

--- a/schematics/deprecated.py
+++ b/schematics/deprecated.py
@@ -12,7 +12,7 @@ def deprecated(func):
     @functools.wraps(func)
     def new_func(*args, **kwargs):
         warnings.warn(
-            "Call to deprecated function {}.".format(func.__name__),
+            "Call to deprecated function {0}.".format(func.__name__),
             category=DeprecationWarning,
             stacklevel=2
         )

--- a/schematics/deprecated.py
+++ b/schematics/deprecated.py
@@ -1,0 +1,124 @@
+
+from .compat import iteritems
+from .datastructures import OrderedDict
+from .types.serializable import Serializable
+
+import warnings
+import functools
+
+
+def deprecated(func):
+    @functools.wraps(func)
+    def new_func(*args, **kwargs):
+        warnings.warn(
+            "Call to deprecated function {}.".format(func.__name__),
+            category=DeprecationWarning,
+            stacklevel=2
+        )
+        return func(*args, **kwargs)
+    return new_func
+
+
+class SchemaCompatibilityMixin(object):
+    """Compatibility layer for previous deprecated Schematics Model API."""
+
+    @property
+    @deprecated
+    def __name__(self):
+        return self.name
+
+    @property
+    @deprecated
+    def _options(self):
+        return self.options
+
+    @property
+    @deprecated
+    def _validator_functions(self):
+        return self.validators
+
+    @property
+    @deprecated
+    def _fields(self):
+        return self.fields
+
+    @property
+    @deprecated
+    def _valid_input_keys(self):
+        return self.valid_input_keys
+
+    @property
+    @deprecated
+    def _serializables(self):
+        return OrderedDict((k, t) for k, t in iteritems(self.fields) if isinstance(t, Serializable))
+
+
+class class_property(property):
+    def __get__(self, instance, type=None):
+        if instance is None:
+            return super(class_property, self).__get__(type, type)
+        return super(class_property, self).__get__(instance, type)
+
+
+class ModelCompatibilityMixin(object):
+    """Compatibility layer for previous deprecated Schematics Model API."""
+
+    @class_property
+    @deprecated
+    def _valid_input_keys(cls):
+        return cls._schema.valid_input_keys
+
+    @class_property
+    @deprecated
+    def _options(cls):
+        return cls._schema.options
+
+    @class_property
+    @deprecated
+    def fields(cls):
+        return cls._schema.fields
+
+    @class_property
+    @deprecated
+    def _fields(cls):
+        return cls._schema.fields
+
+    @class_property
+    @deprecated
+    def _field_list(cls):
+        return list(iteritems(cls._schema.fields))
+
+    @class_property
+    @deprecated
+    def _serializables(cls):
+        return cls._schema._serializables
+
+    @class_property
+    @deprecated
+    def _validator_functions(cls):
+        return cls._schema.validators
+
+
+def patch_models():
+    global models_Model
+    from . import schema
+    from . import models
+    models_Model = models.Model
+    class Model(ModelCompatibilityMixin, models.Model):
+        __doc__ = models.Model.__doc__
+    models.Model = Model
+    models.ModelOptions = schema.SchemaOptions  # deprecated alias
+
+
+def patch_schema():
+    global schema_Schema
+    from . import schema
+    schema_Schema = schema.Schema
+    class Schema(SchemaCompatibilityMixin, schema.Schema):
+        __doc__ = schema.Schema.__doc__
+    schema.Schema = Schema
+
+
+def patch_all():
+    patch_schema()
+    patch_models()

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -48,7 +48,7 @@ def atoms(schema, instance_or_dict, keys=atom._fields, filter=None):
                 value = Undefined
             atom_dict['value'] = value
 
-        atom_tuple = atom(**{k: atom_dict.get(k) for k in keys})
+        atom_tuple = atom(**dict((k, atom_dict.get(k)) for k in keys))
         if filter is None:
             yield atom_tuple
         elif filter(atom_tuple):

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -1,7 +1,6 @@
 
 from .common import * # pylint: disable=redefined-builtin
 from .undefined import Undefined
-from .inspection import LOG
 
 from collections import namedtuple
 
@@ -50,7 +49,6 @@ def atoms(schema, instance_or_dict, keys=atom._fields, filter=None):
             atom_dict['value'] = value
 
         atom_tuple = atom(**{k: atom_dict.get(k) for k in keys})
-        LOG(atom_tuple)
         if filter is None:
             yield atom_tuple
         elif filter(atom_tuple):

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -30,7 +30,6 @@ def atoms(schema, mapping, keys=Atom._fields, filter=None):
     :type filter: Callable[[Atom], bool]
     :param filter:
         Function to filter out atoms from the iteration.
-
     """
     atom_dict = Atom()._asdict()
     keys_set = set(keys)
@@ -58,3 +57,14 @@ def atoms(schema, mapping, keys=Atom._fields, filter=None):
             yield atom_tuple
         elif filter(atom_tuple):
             yield atom_tuple
+
+
+class atom_filter:
+
+    @staticmethod
+    def has_setter(atom):
+        return getattr(atom.field, 'fset', None) is not None
+
+    @staticmethod
+    def not_setter(atom):
+        return not atom_filter.has_setter(atom)

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -1,0 +1,59 @@
+
+from .common import * # pylint: disable=redefined-builtin
+from .undefined import Undefined
+from .inspection import LOG
+
+from collections import namedtuple
+
+atom = namedtuple('atom', ('name', 'field', 'value'))
+atom.__new__.__defaults__ = (None,) * len(atom._fields)
+
+
+def atoms(schema, instance_or_dict, keys=atom._fields, filter=None):
+    """
+    Iterator for the atomic components of a model definition and relevant
+    data that creates a 3-tuple of the field's name, its type instance and
+    its value.
+
+    :param schema:
+        The Schema definition.
+    :param instance_or_dict:
+        The structure where fields from cls are mapped to values. The only
+        expectation for this structure is that it implements a ``Mapping``
+        interface.
+    :param keys:
+        Tuple specifying the output of the iterator. Valid keys are:
+            `name`: the field name
+            `field`: the field descriptor object
+            `value`: the current value set on the field
+        Specifying invalid keys will raise an exception.
+    """
+    atom_dict = atom()._asdict()
+    keys_set = set(keys)
+    if not keys_set.issubset(atom_dict):
+        raise TypeError('invalid key specified')
+
+    has_value = (instance_or_dict is not None) and ('value' in keys_set)
+
+    for field_name, field in iteritems(schema.fields):
+        atom_dict['name'] = field_name
+        atom_dict['field'] = field
+        atom_dict['value'] = Undefined
+
+        if has_value:
+            try:
+                value = getattr(instance_or_dict, field_name)
+            except AttributeError:
+                value = instance_or_dict.get(field_name, Undefined)
+            except:
+                value = Undefined
+            atom_dict['value'] = value
+
+        atom_tuple = atom(**{k: atom_dict.get(k) for k in keys})
+        LOG(atom_tuple)
+        if filter is None:
+            yield atom_tuple
+        elif filter(atom_tuple):
+            yield atom_tuple
+        else:
+            continue

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -31,7 +31,7 @@ def atoms(schema, mapping, keys=Atom._fields, filter=None):
     :param filter:
         Function to filter out atoms from the iteration.
     """
-    atom_dict = Atom()._asdict()
+    atom_dict = dict.fromkeys(Atom._fields)
     keys_set = set(keys)
     if not keys_set.issubset(atom_dict):
         raise TypeError('invalid key specified')

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -1,38 +1,43 @@
 
-from .common import * # pylint: disable=redefined-builtin
+from .compat import iteritems
 from .undefined import Undefined
-
 from collections import namedtuple
 
-atom = namedtuple('atom', ('name', 'field', 'value'))
-atom.__new__.__defaults__ = (None,) * len(atom._fields)
+Atom = namedtuple('Atom', ('name', 'field', 'value'))
+Atom.__new__.__defaults__ = (None,) * len(Atom._fields)
 
 
-def atoms(schema, instance_or_dict, keys=atom._fields, filter=None):
+def atoms(schema, mapping, keys=Atom._fields, filter=None):
     """
     Iterator for the atomic components of a model definition and relevant
     data that creates a 3-tuple of the field's name, its type instance and
     its value.
 
+    :type schema: schematics.schema.Schema
     :param schema:
         The Schema definition.
-    :param instance_or_dict:
-        The structure where fields from cls are mapped to values. The only
+    :param mapping:
+        The structure where fields from schema are mapped to values. The only
         expectation for this structure is that it implements a ``Mapping``
         interface.
+    :type keys: Tuple[str, str, str]
     :param keys:
         Tuple specifying the output of the iterator. Valid keys are:
             `name`: the field name
             `field`: the field descriptor object
             `value`: the current value set on the field
         Specifying invalid keys will raise an exception.
+    :type filter: Callable[[Atom], bool]
+    :param filter:
+        Function to filter out atoms from the iteration.
+
     """
-    atom_dict = atom()._asdict()
+    atom_dict = Atom()._asdict()
     keys_set = set(keys)
     if not keys_set.issubset(atom_dict):
         raise TypeError('invalid key specified')
 
-    has_value = (instance_or_dict is not None) and ('value' in keys_set)
+    has_value = (mapping is not None) and ('value' in keys_set)
 
     for field_name, field in iteritems(schema.fields):
         atom_dict['name'] = field_name
@@ -41,17 +46,15 @@ def atoms(schema, instance_or_dict, keys=atom._fields, filter=None):
 
         if has_value:
             try:
-                value = getattr(instance_or_dict, field_name)
+                value = getattr(mapping, field_name)
             except AttributeError:
-                value = instance_or_dict.get(field_name, Undefined)
-            except:
+                value = mapping.get(field_name, Undefined)
+            except Exception:
                 value = Undefined
             atom_dict['value'] = value
 
-        atom_tuple = atom(**dict((k, atom_dict.get(k)) for k in keys))
+        atom_tuple = Atom(**dict((k, atom_dict.get(k)) for k in keys))
         if filter is None:
             yield atom_tuple
         elif filter(atom_tuple):
             yield atom_tuple
-        else:
-            continue

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -16,6 +16,7 @@ def atoms(schema, mapping, keys=Atom._fields, filter=None):
     :type schema: schematics.schema.Schema
     :param schema:
         The Schema definition.
+    :type mapping: Mapping
     :param mapping:
         The structure where fields from schema are mapped to values. The only
         expectation for this structure is that it implements a ``Mapping``
@@ -27,9 +28,11 @@ def atoms(schema, mapping, keys=Atom._fields, filter=None):
             `field`: the field descriptor object
             `value`: the current value set on the field
         Specifying invalid keys will raise an exception.
-    :type filter: Callable[[Atom], bool]
+    :type filter: Optional[Callable[[Atom], bool]]
     :param filter:
         Function to filter out atoms from the iteration.
+
+    :rtype: Iterable[Atom]
     """
     atom_dict = dict.fromkeys(Atom._fields)
     keys_set = set(keys)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -261,10 +261,9 @@ class Model(object):
         :param raw_data:
             The data to be imported.
         """
-        should_validate = kwargs.get('validate', False)
         data = self._convert(raw_data, recursive=recursive, **kwargs)
         self._data.update(data)
-        if should_validate:
+        if kwargs.get('validate', False):
             self.validate(convert=False)
         return self
 
@@ -276,8 +275,11 @@ class Model(object):
         :param raw_data:
             New data to be imported and converted
         """
-        raw_data = raw_data or {}
-        raw_data.update(self._data.raw)
+        input_data = raw_data or {}
+        if hasattr(input_data, '_data'):
+            input_data = input_data._data.raw
+        raw_data = dict(self._data.raw)
+        raw_data.update(input_data)
         kwargs['trusted_data'] = kwargs.get('trusted_data') or {}
         kwargs['trusted_data'].update(self._data.valid)
         kwargs['convert'] = getattr(context, 'convert', kwargs.get('convert', True))
@@ -382,7 +384,10 @@ class Model(object):
         else:
             memo.add(key)
         try:
-            return self._data == other._data
+            for k in self:
+                if self.get(k) != other.get(k):
+                    return False
+            return True
         finally:
             memo.remove(key)
 

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -231,11 +231,11 @@ class Model(object):
         """
         if raw_data and raw_data is not self:
             self._raw_data.update(raw_data)
-        kw['trusted_data'] = self._data
-        kw['convert'] = getattr(context, 'convert', None) or kw.get('convert', True)
-        should_validate = getattr(context, 'validate', None) or kw.get('validate', False)
+        kwargs['trusted_data'] = self._data
+        kwargs['convert'] = getattr(context, 'convert', None) or kwargs.get('convert', True)
+        should_validate = getattr(context, 'validate', None) or kwargs.get('validate', False)
         func = validate if should_validate else convert
-        return func(self._schema, self, self._raw_data, oo=True, context=context, **kw)
+        return func(self._schema, self, self._raw_data, oo=True, context=context, **kwargs)
 
     def export(self, field_converter=None, role=None, app_data=None, **kwargs):
         return export_loop(self._schema, self, field_converter=field_converter,

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -9,6 +9,7 @@ from types import FunctionType
 from .common import * # pylint: disable=redefined-builtin
 from .datastructures import OrderedDict, Context
 from .exceptions import *
+from .iteration import atoms
 from .transforms import (
     atoms, export_loop,
     convert, to_native, to_primitive,

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -291,8 +291,14 @@ class Model(object):
         return to_primitive(self._schema, self, role=role, app_data=app_data, **kwargs)
 
     def serialize(self, *args, **kwargs):
-        self.validate()
-        return self.to_primitive(*args, **kwargs)
+        raw_data = self._data.raw
+        try:
+            self.validate(apply_defaults=True)
+        except DataError:
+            pass
+        data = self.to_primitive(*args, **kwargs)
+        self._data.raw = raw_data
+        return data
 
     def atoms(self):
         """

--- a/schematics/role.py
+++ b/schematics/role.py
@@ -1,0 +1,113 @@
+
+from .compat import str_compat
+
+import collections
+
+
+@str_compat
+class Role(collections.Set):
+
+    """
+    A ``Role`` object can be used to filter specific fields against a sequence.
+
+    The ``Role`` contains two things: a set of names and a function.
+    The function describes how to filter, taking a field name as input and then
+    returning ``True`` or ``False`` to indicate that field should or should not
+    be skipped.
+
+    A ``Role`` can be operated on as a ``Set`` object representing the fields
+    it has an opinion on.  When Roles are combined with other roles, only the
+    filtering behavior of the first role is used.
+    """
+
+    def __init__(self, function, fields):
+        self.function = function
+        self.fields = set(fields)
+
+    def _from_iterable(self, iterable):
+        return Role(self.function, iterable)
+
+    def __contains__(self, value):
+        return value in self.fields
+
+    def __iter__(self):
+        return iter(self.fields)
+
+    def __len__(self):
+        return len(self.fields)
+
+    def __eq__(self, other):
+        return (self.function.__name__ == other.function.__name__ and
+                self.fields == other.fields)
+
+    def __str__(self):
+        return '%s(%s)' % (self.function.__name__,
+                           ', '.join("'%s'" % f for f in self.fields))
+
+    def __repr__(self):
+        return '<Role %s>' % str(self)
+
+    # edit role fields
+    def __add__(self, other):
+        fields = self.fields.union(other)
+        return self._from_iterable(fields)
+
+    def __sub__(self, other):
+        fields = self.fields.difference(other)
+        return self._from_iterable(fields)
+
+    # apply role to field
+    def __call__(self, name, value):
+        return self.function(name, value, self.fields)
+
+    # static filter functions
+    @staticmethod
+    def wholelist(name, value, seq):
+        """
+        Accepts a field name, value, and a field list.  This function
+        implements acceptance of all fields by never requesting a field be
+        skipped, thus returns False for all input.
+
+        :param name:
+            The field name to inspect.
+        :param value:
+            The field's value.
+        :param seq:
+            The list of fields associated with the ``Role``.
+        """
+        return False
+
+    @staticmethod
+    def whitelist(name, value, seq):
+        """
+        Implements the behavior of a whitelist by requesting a field be skipped
+        whenever its name is not in the list of fields.
+
+        :param name:
+            The field name to inspect.
+        :param value:
+            The field's value.
+        :param seq:
+            The list of fields associated with the ``Role``.
+        """
+
+        if seq is not None and len(seq) > 0:
+            return name not in seq
+        return True
+
+    @staticmethod
+    def blacklist(name, value, seq):
+        """
+        Implements the behavior of a blacklist by requesting a field be skipped
+        whenever its name is found in the list of fields.
+
+        :param k:
+            The field name to inspect.
+        :param v:
+            The field's value.
+        :param seq:
+            The list of fields associated with the ``Role``.
+        """
+        if seq is not None and len(seq) > 0:
+            return name in seq
+        return False

--- a/schematics/schema.py
+++ b/schematics/schema.py
@@ -50,7 +50,12 @@ class SchemaOptions(object):
 
 class Field(object):
 
+    __slots__ = ('name', 'type')
+
     def __init__(self, name, field_type):
         assert isinstance(field_type, (BaseType, Serializable))
         self.name = name
         self.type = field_type
+
+    def is_settable(self):
+        return getattr(self.type, 'fset', None) is not None

--- a/schematics/schema.py
+++ b/schematics/schema.py
@@ -1,0 +1,75 @@
+
+from .common import DEFAULT, NONEMPTY
+from .datastructures import OrderedDict
+from .types import BaseType
+from .types.serializable import ComputedType
+
+import itertools
+import inspect
+
+
+class SchemaCompatibilityMixin(object):
+    """Compatibility layer for previous deprecated Schematics Model API."""
+
+    @property  # deprecated
+    def __name__(self):
+        return self.name
+
+    @property  # deprecated
+    def _options(self):
+        return self.options
+
+    @property  # deprecated
+    def _valid_input_keys(self):
+        return self.valid_input_keys
+
+    @property  # deprecated
+    def _serializables(self):
+        return OrderedDict((k, t) for k, t in self.fields.items() if isinstance(t, ComputedType))
+
+
+class Schema(SchemaCompatibilityMixin, object):
+
+    def __init__(self, name, *fields, **kw):
+        self.name = name
+        self.model = kw.get('model', None)
+        self.options = kw.get('options', SchemaOptions(self.model))
+        self.validators = kw.get('validators', {})
+        self.fields = OrderedDict()
+        for field in fields:
+            self.append_field(field)
+
+    @property
+    def valid_input_keys(self):
+        return set(itertools.chain(*(t.get_input_keys() for t in self.fields.values())))
+
+    def append_field(self, field):
+        self.fields[field.name] = field.type
+        field.type._setup(field.name, self.model)
+
+
+class SchemaOptions(object):
+
+    def __init__(self, namespace=None, roles=None, export_level=DEFAULT,
+            serialize_when_none=None, export_order=False):
+        self.namespace = namespace
+        self.roles = roles or {}
+        self.export_level = export_level
+        if serialize_when_none is True:
+            self.export_level = DEFAULT
+        elif serialize_when_none is False:
+            self.export_level = NONEMPTY
+        self.export_order = export_order
+
+    def __iter__(self):
+        for key, value in inspect.getmembers(self):
+            if not key.startswith("_"):
+                yield key, value
+
+
+class Field(object):
+
+    def __init__(self, name, field_type):
+        assert isinstance(field_type, BaseType)
+        self.name = name
+        self.type = field_type

--- a/schematics/schema.py
+++ b/schematics/schema.py
@@ -1,5 +1,5 @@
 
-from .compat import iteritems, itervalues
+from .compat import itervalues
 from .common import DEFAULT, NONEMPTY
 from .datastructures import OrderedDict
 from .types import BaseType
@@ -9,35 +9,7 @@ import itertools
 import inspect
 
 
-class SchemaCompatibilityMixin(object):
-    """Compatibility layer for previous deprecated Schematics Model API."""
-
-    @property  # deprecated
-    def __name__(self):
-        return self.name
-
-    @property  # deprecated
-    def _options(self):
-        return self.options
-
-    @property  # deprecated
-    def _validator_functions(self):
-        return self.validators
-
-    @property  # deprecated
-    def _fields(self):
-        return self.fields
-
-    @property  # deprecated
-    def _valid_input_keys(self):
-        return self.valid_input_keys
-
-    @property  # deprecated
-    def _serializables(self):
-        return OrderedDict((k, t) for k, t in iteritems(self.fields) if isinstance(t, Serializable))
-
-
-class Schema(SchemaCompatibilityMixin, object):
+class Schema(object):
 
     def __init__(self, name, *fields, **kw):
         self.name = name

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -153,6 +153,10 @@ def import_loop(schema, mutable, raw_data=None, field_converter=None, trusted_da
                 value = _field_converter(field, value, field_context)
             except (FieldError, CompoundError) as exc:
                 errors[serialized_field_name] = exc
+                if context.apply_defaults:
+                    value = field.default
+                    if value is not Undefined:
+                        data[field_name] = value
                 if isinstance(exc, DataError):
                     data[field_name] = exc.partial_data
                 continue

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -12,6 +12,7 @@ from .exceptions import *
 from .undefined import Undefined
 from .util import listify
 from .iteration import atoms
+from .models import Model
 
 try:
     from collections import OrderedDict

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -12,7 +12,6 @@ from .exceptions import *
 from .undefined import Undefined
 from .util import listify
 from .iteration import atoms
-from .models import Model
 
 try:
     from collections import OrderedDict

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -12,6 +12,7 @@ from .datastructures import Context
 from .exceptions import *
 from .undefined import Undefined
 from .util import listify
+from .iteration import atoms
 
 try:
     from collections import OrderedDict
@@ -262,33 +263,6 @@ def export_loop(cls, instance_or_dict, field_converter=None, role=None, raise_er
     return data
 
 
-def atoms(cls, instance_or_dict):
-    """
-    Iterator for the atomic components of a model definition and relevant
-    data that creates a 3-tuple of the field's name, its type instance and
-    its value.
-
-    :param cls:
-        The model definition.
-    :param instance_or_dict:
-        The structure where fields from cls are mapped to values. The only
-        expectation for this structure is that it implements a ``Mapping``
-        interface.
-    """
-    field_getter = serializable_getter = instance_or_dict.get
-    try:
-        field_getter = instance_or_dict._data.get
-    except AttributeError:
-        pass
-
-    sequences = ((cls._field_list, field_getter),
-                 (cls._serializables.items(), serializable_getter))
-    for sequence, get in sequences:
-        for field_name, field in sequence:
-            yield (field_name, field, get(field_name, Undefined))
-
-
-
 ###
 # Field filtering
 ###
@@ -530,8 +504,8 @@ def get_export_context(field_converter=to_native_converter, **options):
 ###
 
 
-def convert(cls, instance_or_dict, **kwargs):
-    return import_loop(cls, instance_or_dict, import_converter, **kwargs)
+def convert(cls, mutable, raw_data, **kwargs):
+    return import_loop(cls, mutable, raw_data, import_converter, **kwargs)
 
 
 def to_native(cls, instance_or_dict, **kwargs):

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -299,13 +299,13 @@ class Role(collections.Set):
     """
     A ``Role`` object can be used to filter specific fields against a sequence.
 
-    The ``Role`` is two things: a set of names and a function.  The function
-    describes how filter taking a field name as input and then returning either
-    ``True`` or ``False``, indicating that field should or should not be
-    skipped.
+    The ``Role`` contains two things: a set of names and a function.
+    The function describes how to filter, taking a field name as input and then
+    returning ``True`` or ``False`` to indicate that field should or should not
+    be skipped.
 
     A ``Role`` can be operated on as a ``Set`` object representing the fields
-    is has an opinion on.  When Roles are combined with other roles, the
+    it has an opinion on.  When Roles are combined with other roles, only the
     filtering behavior of the first role is used.
     """
 
@@ -353,7 +353,7 @@ class Role(collections.Set):
     @staticmethod
     def wholelist(name, value, seq):
         """
-        Accepts a field name, value, and a field list.  This functions
+        Accepts a field name, value, and a field list.  This function
         implements acceptance of all fields by never requesting a field be
         skipped, thus returns False for all input.
 
@@ -370,7 +370,7 @@ class Role(collections.Set):
     def whitelist(name, value, seq):
         """
         Implements the behavior of a whitelist by requesting a field be skipped
-        whenever it's name is not in the list of fields.
+        whenever its name is not in the list of fields.
 
         :param name:
             The field name to inspect.
@@ -388,7 +388,7 @@ class Role(collections.Set):
     def blacklist(name, value, seq):
         """
         Implements the behavior of a blacklist by requesting a field be skipped
-        whenever it's name is found in the list of fields.
+        whenever its name is found in the list of fields.
 
         :param k:
             The field name to inspect.

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -131,6 +131,8 @@ def import_loop(cls, mutable, raw_data=None, field_converter=None, trusted_data=
             if field.is_compound:
                 if context.trusted_data and context.recursive:
                     td = context.trusted_data.get(field_name)
+                    if not isinstance(td, (dict, Model)):
+                        td = {field_name: td}
                 else:
                     td = {}
                 if _model_mapping:

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -131,8 +131,6 @@ def import_loop(cls, mutable, raw_data=None, field_converter=None, trusted_data=
             if field.is_compound:
                 if context.trusted_data and context.recursive:
                     td = context.trusted_data.get(field_name)
-                    if not isinstance(td, (dict, Model)):
-                        td = {field_name: td}
                 else:
                     td = {}
                 if _model_mapping:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -2,12 +2,10 @@
 
 from __future__ import unicode_literals, absolute_import
 
-import collections
 from collections import Iterable, Sequence, Mapping
 import itertools
 
 from ..common import * # pylint: disable=redefined-builtin
-from ..datastructures import OrderedDict
 from ..exceptions import *
 from ..transforms import (
     export_loop,
@@ -111,6 +109,8 @@ class ModelType(CompoundType):
     def pre_setattr(self, value):
         if value is not None \
           and not isinstance(value, Model):
+            if not isinstance(value, dict):
+                raise ConversionError('Model conversion requires a model or dict')
             value = self.model_class(value)
         return value
 

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -88,7 +88,6 @@ class Serializable(object):
     def __set__(self, instance, value):
         if self.fset is None:
             raise AttributeError("can't set attribute %s" % self.name)
-        value = self.type.convert(value, get_import_context(oo=True))
         value = self.type.pre_setattr(value)
         self.fset(instance, value)
 

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -91,8 +91,17 @@ class Serializable(object):
         self.fset = fset
         return self
 
+    def _repr_info(self):
+        return self.type.__class__.__name__
+
     def __deepcopy__(self, memo):
         return self.__class__(self.func, copy.deepcopy(self.type))
+
+    def __repr__(self):
+        type_ = "%s(%s) instance" % (self.__class__.__name__, self._repr_info() or '')
+        model = " on %s" % self.owner_model.__name__ if self.owner_model else ''
+        field = " as '%s'" % self.name if self.name else ''
+        return "<%s>" % (type_ + model + field)
 
 
 __all__ = module_exports(__name__)

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -9,6 +9,7 @@ from types import FunctionType
 from ..common import *
 from ..exceptions import *
 from ..undefined import Undefined
+from ..transforms import get_import_context
 
 from .base import BaseType, TypeMeta
 
@@ -87,6 +88,7 @@ class Serializable(object):
     def __set__(self, instance, value):
         if self.fset is None:
             raise AttributeError("can't set attribute %s" % self.name)
+        value = self.type.convert(value, get_import_context(oo=True))
         value = self.type.pre_setattr(value)
         self.fset(instance, value)
 

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -76,7 +76,7 @@ def mutate(schema, mutable, raw_data):
         if value is Undefined:
             continue
         try:
-            field.fset(mutable, value)
+            field.__set__(mutable, value)
         except AttributeError:
             # TODO: aggregate serializable errors into errors dict
             pass

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -52,7 +52,6 @@ def validate(schema, mutable, raw_data=None, trusted_data=None,
         convert=convert)
 
     errors = {}
-    _mutate(schema, mutable, raw_data)
     try:
         data = import_loop(schema, mutable, raw_data, trusted_data=trusted_data,
             context=context, **kwargs)
@@ -66,22 +65,6 @@ def validate(schema, mutable, raw_data=None, trusted_data=None,
         raise DataError(errors, data)
 
     return data
-
-
-def _mutate(schema, mutable, raw_data):
-    """
-    Mutates the converted data before validation. Allows Schema fields
-    to modify/create data values.
-    """
-    for field_name, field, value in atoms(schema, raw_data, filter=atom_filter.has_setter):
-        if value is Undefined:
-            continue
-        try:
-            field.__set__(mutable, value)
-        except AttributeError:
-            # TODO: aggregate serializable errors into errors dict
-            pass
-    raw_data.update(mutable)
 
 
 def _validate_model(schema, mutable, data, context):

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals, absolute_import
 
 import inspect
+import functools
 
 from .common import * # pylint: disable=redefined-builtin
 from .datastructures import Context
@@ -79,6 +80,7 @@ def mutate(schema, mutable, raw_data):
         except AttributeError:
             # TODO: aggregate serializable errors into errors dict
             pass
+    raw_data.update(mutable)
 
 
 def _validate_model(cls, data, context):

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -9,7 +9,7 @@ from .common import * # pylint: disable=redefined-builtin
 from .datastructures import Context
 from .exceptions import FieldError, DataError
 from .transforms import import_loop, validation_converter
-from .undefined import Undefined
+from .iteration import atoms
 
 
 def validate(cls, instance_or_dict, trusted_data=None, partial=False, strict=False,

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -149,5 +149,5 @@ def test_serializable_inheritance():
     assert A.s is A._serializables['s'] is not B._serializables['s']
     assert B.s is B._serializables['s']
     assert A.s.type is not B.s.type
-    assert A.s.func is B.s.func
+    assert A.s.fget is B.s.fget
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -10,7 +10,7 @@ from schematics.exceptions import DataError
 
 def test_reason_why_we_must_bind_fields():
     class Person(Model):
-        name = StringType(required=True)
+        name = StringType()
 
     p1 = Person()
     p2 = Person()
@@ -23,8 +23,7 @@ def test_reason_why_we_must_bind_fields():
 
     p1.name = "Jóhann"
     p1.validate()
-    with pytest.raises(DataError):
-        p2.validate()
+    p2.validate()
 
     assert p1 != p2
     assert id(p1) != id(p2)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -67,15 +67,13 @@ def test_validate_with_instance_level_validators():
         id = IntType()
 
         def validate_id(self, data, value, context):
-            if p1._initial['id'] != value:
-                p1._data['id'] = p1._initial['id']
+            if self.id:
                 raise ValidationError('Cannot change id')
 
-    p1 = Player({'id': 4})
-    p1.id = 3
+    p1 = Player(trusted_data={'id': 4})
 
     try:
-        validate(Player, p1)
+        validate(Player, p1, {'id': 3})
     except DataError as e:
         assert 'id' in e.messages
         assert 'Cannot change id' in e.messages['id']

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,85 @@
+
+import pytest
+
+from schematics.types import StringType, IntType
+from schematics.exceptions import DataError, ValidationError
+from schematics.models import Model
+
+
+def test_dont_serialize_invalid_data():
+    """
+    Serialization must always contain just the subset of valid
+    data from the model.
+    """
+    class Player(Model):
+        code = StringType(max_length=4, default=None, serialize_when_none=True)
+
+    p1 = Player({'code': 'invalid1'})
+    assert p1.serialize() == {'code': None}
+    with pytest.raises(DataError):
+        p1.validate()
+    assert p1.serialize() == {'code': None}
+
+
+def test_dont_overwrite_with_invalid_data():
+    """
+    Model-level validators are black-boxes and we should not assume
+    that we can set the instance data at any time.
+
+    """
+    class Player(Model):
+        id = IntType()
+        name = StringType()
+
+        def validate_id(self, context, value):
+            if self._data.valid.get('id'):
+                raise ValidationError('Cannot change id')
+
+    p1 = Player({'id': 4})
+    p1.validate()
+    p1.id = 3
+    p1.name = 'Douglas'
+    with pytest.raises(DataError):
+        p1.validate()
+    assert p1.id == 4
+    assert p1.name == 'Douglas'
+
+
+def test_model_state_after_multiple_validation():
+    """
+    Validation must maintain a sane state after multiple operations.
+    """
+    class Player(Model):
+        id = IntType()
+        code = StringType(max_length=4)
+
+    p1 = Player({'id': 4})
+    p1.validate()
+    assert p1.serialize() == {'id': 4, 'code': None}
+    p1.code = 'AAA'
+    p1.validate()
+    assert p1.serialize() == {'id': 4, 'code': 'AAA'}
+    p1.code = 'BBB'
+    p1.validate()
+    assert p1.serialize() == {'id': 4, 'code': 'BBB'}
+    p1.code = 'CCCERR'
+    with pytest.raises(DataError):
+        p1.validate()
+    assert p1.serialize() == {'id': 4, 'code': 'BBB'}
+    p1.validate()
+    assert p1.serialize() == {'id': 4, 'code': 'BBB'}
+
+
+def test_dont_forget_required_fields_after_multiple_validation():
+        """
+        Validation should not forget about required fields, even when invalid
+        data is cleared from input, since it doesn't rely on actual input.
+        """
+        class Player(Model):
+            code = StringType(required=True)
+
+        p1 = Player()
+        with pytest.raises(DataError):
+            p1.validate()
+        with pytest.raises(DataError):
+            p1.validate()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -184,6 +184,7 @@ def test_validation_uses_internal_state():
 
 def test_validation_fails_if_internal_state_is_invalid():
     class User(Model):
+        status = StringType()
         name = StringType(required=True)
         age = IntType(required=True)
 
@@ -196,8 +197,9 @@ def test_validation_fails_if_internal_state_is_invalid():
         "age": ["This field is required."],
     }
 
-    assert u.name is None
-    assert u.age is None
+    assert u.status is None
+    with pytest.raises(UndefinedValueError):
+        u.name == u.age
 
 
 def test_returns_nice_conversion_errors():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -291,7 +291,7 @@ def test_explicit_values_override_defaults():
 
 
 def test_good_options_args():
-    mo = ModelOptions(klass=None, roles=None)
+    mo = ModelOptions(roles=None)
     assert mo is not None
 
     assert mo.roles == {}
@@ -299,7 +299,6 @@ def test_good_options_args():
 
 def test_bad_options_args():
     args = {
-        'klass': None,
         'roles': None,
         'badkw': None,
     }
@@ -310,7 +309,7 @@ def test_bad_options_args():
 
 def test_no_options_args():
     args = {}
-    mo = ModelOptions(None, **args)
+    mo = ModelOptions(**args)
     assert mo is not None
 
 
@@ -332,10 +331,10 @@ def test_options_parsing_from_model():
 def test_options_parsing_from_optionsclass():
     class FooOptions(ModelOptions):
 
-        def __init__(self, klass, **kwargs):
+        def __init__(self, **kwargs):
             kwargs['namespace'] = kwargs.get('namespace') or 'foo'
             kwargs['roles'] = kwargs.get('roles') or {}
-            super(FooOptions, self).__init__(klass, **kwargs)
+            super(FooOptions, self).__init__(**kwargs)
 
     class Foo(Model):
         __optionsclass__ = FooOptions

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -38,7 +38,7 @@ def player_schema():
 
 @pytest.fixture
 def player_data():
-    return {'id': '1', 'full_name': 'Arthur Dent', 'towel': True}
+    return {'id': '42', 'full_name': 'Arthur Dent', 'towel': True}
 
 
 def test_functional_schema_required(player_schema):
@@ -52,16 +52,16 @@ def test_functional_schema(player_schema, player_data):
 
     data = input_data  # state = 'RAW'
 
-    expected = {'id': 1, 'full_name': 'Arthur Dent'}
+    expected = {'id': 42, 'full_name': 'Arthur Dent'}
     data = convert(schema, data, partial=True)
     assert data == expected  # state = 'CONVERTED'
 
-    expected = {'id': 1, 'first_name': 'Arthur', 'last_name': 'Dent',
+    expected = {'id': 42, 'first_name': 'Arthur', 'last_name': 'Dent',
                 'full_name': 'Arthur Dent'}
     data = validate(schema, data, convert=False, partial=False)
     assert data == expected  # state = 'VALIDATED'
 
-    expected = {'id': 1, 'first_name': 'Arthur', 'last_name': 'Dent',
+    expected = {'id': 42, 'first_name': 'Arthur', 'last_name': 'Dent',
                 'full_name': 'Arthur Dent'}
     data = to_primitive(schema, data)
     assert data == expected  # state = 'SERIALIZED'
@@ -127,7 +127,7 @@ def test_object_model_equivalence():
         def full_name(self, value):
             set_full_name(self, value)
 
-    input_data = {'id': '1', 'full_name': 'Arthur Dent', 'towel': True}
+    input_data = {'id': '42', 'full_name': 'Arthur Dent', 'towel': True}
 
     data = input_data.copy()
     player = Player(input_data, strict=False, validate=False, init=False)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from schematics.models import Model
+from schematics.types import StringType, IntType, calculated, serializable
+from schematics.schema import Schema, Field
+from schematics.transforms import convert, to_primitive
+from schematics.exceptions import DataError
+from schematics.validate import validate
+from schematics.contrib.machine import Machine
+
+
+@pytest.fixture
+def player_schema():
+
+    def get_full_name(data, *a, **kw):
+        if not data:
+            return
+        return '{first_name} {last_name}'.format(**data)
+
+    def set_full_name(data, value, *a, **kw):
+        if not value:
+            return
+        data['first_name'], _, data['last_name'] = value.partition(' ')
+
+    schema = Schema('Player',
+        Field('id', IntType()),
+        Field('first_name', StringType(required=True)),
+        Field('last_name', StringType(required=True)),
+        Field('full_name', calculated(
+            type=StringType(),
+            fget=get_full_name,
+            fset=set_full_name))
+    )
+
+    return schema
+
+
+@pytest.fixture
+def player_data():
+    return {'id': '1', 'full_name': 'Arthur Dent', 'towel': True}
+
+
+def test_functional_schema_required(player_schema):
+    with pytest.raises(DataError):
+        validate(player_schema, {}, partial=False)
+
+
+def test_functional_schema(player_schema, player_data):
+    schema = player_schema
+    input_data = player_data
+
+    data = input_data  # state = 'RAW'
+
+    expected = {'id': 1, 'full_name': 'Arthur Dent'}
+    data = convert(schema, data, partial=True)
+    assert data == expected  # state = 'CONVERTED'
+
+    expected = {'id': 1, 'first_name': 'Arthur', 'last_name': 'Dent',
+                'full_name': 'Arthur Dent'}
+    data = validate(schema, data, convert=False, partial=False)
+    assert data == expected  # state = 'VALIDATED'
+
+    expected = {'id': 1, 'first_name': 'Arthur', 'last_name': 'Dent',
+                'full_name': 'Arthur Dent'}
+    data = to_primitive(schema, data)
+    assert data == expected  # state = 'SERIALIZED'
+
+
+def test_state_machine_equivalence(player_schema, player_data):
+    schema = player_schema
+    input_data = player_data
+
+    data = input_data.copy()
+    machine = Machine(input_data, schema)
+    assert machine.state == 'raw'
+
+    data = convert(schema, data, partial=True)
+    machine.convert()
+    assert machine.state == 'converted'
+    assert data == machine.data
+
+    data = validate(schema, data, convert=False, partial=False)
+    machine.validate()
+    assert machine.state == 'validated'
+    assert data == machine.data
+
+    data = to_primitive(schema, data)
+    machine.serialize()
+    assert machine.state == 'serialized'
+    assert data == machine.data
+
+
+def test_object_model_equivalence():
+    # functional
+    def get_full_name(data, *a, **kw):
+        if not data:
+            return
+        return '{first_name} {last_name}'.format(**data)
+
+    def set_full_name(data, value, *a, **kw):
+        if not value:
+            return
+        data['first_name'], _, data['last_name'] = value.partition(' ')
+
+    schema = Schema('Player',
+        Field('id', IntType()),
+        Field('first_name', StringType(required=True)),
+        Field('last_name', StringType(required=True)),
+        Field('full_name', calculated(
+            type=StringType(),
+            fget=get_full_name,
+            fset=set_full_name))
+    )
+
+    # object
+    class Player(Model):
+        id = IntType()
+        first_name = StringType(required=True)
+        last_name = StringType(required=True)
+
+        @serializable(type=StringType())
+        def full_name(self):
+            return get_full_name(self)
+
+        @full_name.setter
+        def full_name(self, value):
+            set_full_name(self, value)
+
+    input_data = {'id': '1', 'full_name': 'Arthur Dent', 'towel': True}
+
+    data = input_data.copy()
+    player = Player(input_data, strict=False, validate=False, init=False)
+
+    data = convert(schema, data, partial=True)
+    p0 = player._data.copy()
+    p1 = player._raw_data.copy()
+    p0.update(p1)
+    assert data == p0
+
+    data = validate(schema, data, convert=False, partial=False)
+    player.validate()
+    p0 = player._data.copy()
+    p1 = player._raw_data.copy()
+    p0.update(p1)
+    assert data == p0
+
+    data = to_primitive(schema, data)
+    player_dict = player.serialize()
+    assert data == player_dict

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -133,17 +133,11 @@ def test_object_model_equivalence():
     player = Player(input_data, strict=False, validate=False, init=False)
 
     data = convert(schema, data, partial=True)
-    p0 = player._data.copy()
-    p1 = player._raw_data.copy()
-    p0.update(p1)
-    assert data == p0
+    assert data == player._data
 
     data = validate(schema, data, convert=False, partial=False)
     player.validate()
-    p0 = player._data.copy()
-    p1 = player._raw_data.copy()
-    p0.update(p1)
-    assert data == p0
+    assert data == player._data
 
     data = to_primitive(schema, data)
     player_dict = player.serialize()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -550,6 +550,45 @@ def test_serializable_setter():
     assert d == {"country_code": "US", "country_name": "United States"}
 
 
+def test_serializable_setter_override():
+    class Player(Model):
+        _id = IntType()
+
+        @serializable(IntType())
+        def id(self):
+            return self._id
+
+        @id.setter
+        def id(self, value):
+            self._id = value
+
+    p = Player()
+    p.id = "1"
+    p.validate()
+
+    assert type(1) == type(p.id)
+    assert 1 == p.id
+
+
+def test_serializable_setter_init():
+    class Location(Model):
+        country_code = StringType()
+
+        @serializable
+        def country_name(self):
+            return "United States" if self.country_code == "US" else "Unknown"
+
+        @country_name.setter
+        def country_name(self, value):
+            self.country_code = {"United States": "US"}.get(value)
+
+    location = Location({"country_name": "United States"})
+    assert location.country_code == "US"
+
+    d = location.serialize()
+    assert d == {"country_code": "US", "country_name": "United States"}
+
+
 def test_roles_work_with_subclassing():
     class Address(Model):
         private_key = StringType()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -530,6 +530,26 @@ def test_serialize_print_none_always_gets_you_something():
     assert d == {}
 
 
+def test_serializable_setter():
+    class Location(Model):
+        country_code = StringType()
+
+        @serializable
+        def country_name(self):
+            return "United States" if self.country_code == "US" else "Unknown"
+
+        @country_name.setter
+        def country_name(self, value):
+            self.country_code = {"United States": "US"}.get(value)
+
+    location = Location()
+    location.country_name = "United States"
+    assert location.country_code == "US"
+
+    d = location.serialize()
+    assert d == {"country_code": "US", "country_name": "United States"}
+
+
 def test_roles_work_with_subclassing():
     class Address(Model):
         private_key = StringType()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -582,7 +582,7 @@ def test_serializable_setter_init():
         def country_name(self, value):
             self.country_code = {"United States": "US"}.get(value)
 
-    location = Location({"country_name": "United States"})
+    location = Location({"country_name": "United States"}, validate=True)
     assert location.country_code == "US"
 
     d = location.serialize()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, pypy, pypy3
+envlist = py26, py27, py33, py34, py35, pypy
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Implements #446 

This is the foundational work to get back compatibility with SQLAlchemy. To do that, the concept of Serializable setters is reintroduced, along with a lower level abstraction of the Model named Schema.

The functional API can now rely on the Schema declaration directly, which simplifies integration by exposing a smaller surface. More work will need to be done to introduce a CompoundType with pure Schema.

Additionally, the concept of data validation stages is introduced (see `contrib/machine.py`) and initial work has been done in the Model to apply that, but it's not fully realized yet. Discussion for a more granular approach will be presented in another PR.