### PR TITLE
Enhancing and addressing some issues around exceptions:

### DIFF
--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -59,7 +59,7 @@ def py_native_string(source):
     return source
 
 
-def str_compat(class_):
+def str_compat(class_, with_repr=False):
     """
     On Python 2, patches the ``__str__`` and ``__repr__`` methods on the given class
     so that the class can be written for Python 3 and Unicode.
@@ -68,6 +68,8 @@ def str_compat(class_):
         if '__str__' in class_.__dict__ and '__unicode__' not in class_.__dict__:
             class_.__unicode__ = class_.__str__
             class_.__str__ = py_native_string(class_.__unicode__)
+    if with_repr:
+        repr_compat(class_)
     return class_
 
 

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -59,7 +59,7 @@ def py_native_string(source):
     return source
 
 
-def str_compat(class_, with_repr=False):
+def str_compat(class_):
     """
     On Python 2, patches the ``__str__`` and ``__repr__`` methods on the given class
     so that the class can be written for Python 3 and Unicode.
@@ -68,8 +68,6 @@ def str_compat(class_, with_repr=False):
         if '__str__' in class_.__dict__ and '__unicode__' not in class_.__dict__:
             class_.__unicode__ = class_.__str__
             class_.__str__ = py_native_string(class_.__unicode__)
-    if with_repr:
-        repr_compat(class_)
     return class_
 
 

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -68,7 +68,11 @@ def str_compat(class_):
         if '__str__' in class_.__dict__ and '__unicode__' not in class_.__dict__:
             class_.__unicode__ = class_.__str__
             class_.__str__ = py_native_string(class_.__unicode__)
+    return class_
+
+
+def repr_compat(class_):
+    if PY2:
         if '__repr__' in class_.__dict__:
             class_.__repr__ = py_native_string(class_.__repr__)
     return class_
-

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals, absolute_import
 
-from collections import MutableMapping, KeysView, ValuesView, ItemsView
+from collections import Mapping, MutableMapping, KeysView, ValuesView, ItemsView, Sequence
 from copy import deepcopy
 from operator import eq
 
@@ -443,6 +443,72 @@ except ImportError:
 
         def __repr__(self):
             return '{0.__class__.__name__}({1})'.format(self, self._map)
+
+
+class FrozenDict(Mapping):
+
+    def __init__(self, value):
+        self._value = dict(value)
+
+    def __getitem__(self, key):
+        return self._value[key]
+
+    def __iter__(self):
+        return iter(self._value)
+
+    def __len__(self):
+        return len(self._value)
+
+    def __hash__(self):
+        if not hasattr(self, "_hash"):
+            _hash = 0
+            for k, v in self._value.items():
+                _hash ^= hash(k)
+                _hash ^= hash(v)
+            self._hash = _hash
+        return self._hash
+
+    def __repr__(self):
+        return repr(self._value)
+
+    def __str__(self):
+        return str(self._value)
+
+
+class FrozenList(Sequence):
+
+    def __init__(self, value):
+        self._list = list(value)
+
+    def __getitem__(self, index):
+        return self._list[index]
+
+    def __len__(self):
+        return len(self._list)
+
+    def __hash__(self):
+        if not hasattr(self, "_hash"):
+            _hash = 0
+            for e in self._list:
+                _hash ^= hash(e)
+            self._hash = _hash
+        return self._hash
+
+    def __repr__(self):
+        return repr(self._list)
+
+    def __str__(self):
+        return str(self._list)
+
+    def __eq__(self, other):
+        if len(self) != len(other):
+            return False
+        for i in range(len(self)):
+            if self[i] != other[i]:
+                return False
+        return True
+
+
 
 
 __all__ = module_exports(__name__)

--- a/schematics/deprecated.py
+++ b/schematics/deprecated.py
@@ -1,4 +1,3 @@
-
 from .compat import iteritems
 from .datastructures import OrderedDict
 from .types.serializable import Serializable

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -77,7 +77,7 @@ class BaseError(Exception):
         return json.dumps(self.to_primitive())
 
     def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, repr(self.errors))
+        return "%s(%s)" % (self.__class__.__name__, repr(self.errors))
 
     def __hash__(self):
         return hash(self.errors)
@@ -102,7 +102,11 @@ class ErrorMessage(object):
         self.info = info
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, str(self))
+        return '%s(%s, %s)' % (
+            self.__class__.__name__,
+            repr(self.summary),
+            repr(self.info)
+        )
 
     def __str__(self):
         if self.info:

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -2,9 +2,73 @@
 
 from __future__ import unicode_literals, absolute_import
 
+import copy
+
 from collections import Sequence
 
 from .common import *
+
+
+@str_compat
+class BaseError(Exception):
+
+    def __init__(self, message, errors=None, *args):
+        """
+        The base class for all Schematics errors.
+
+        message should be a human-readable message,
+        while errors is a machine-readable list, or dictionary.
+
+        if None is passed as the message, and error is populated,
+        the primitive representation will be serialized.
+
+        the Python logging module expects exceptions to be hashable
+        and therefore immutable. As a result, it is not possible to
+        mutate BaseError's error list or dict after initialization.
+        """
+        if message is None and errors is not None:
+            message = str(self._to_primitive(errors))
+        super(BaseError, self).__init__(message)
+        self._errors = errors
+
+    @property
+    def errors(self):
+        return copy.deepcopy(self._errors)
+
+    @property
+    def messages(self):
+        """ an alias for errors, provided for compatibility with V1. """
+        return self.errors
+
+    def to_primitive(self):
+        """
+        converts the errors dict to a primitive representation of dicts,
+        list and strings.
+        """
+        return self._to_primitive(self._errors)
+
+    @classmethod
+    def _to_primitive(cls, obj):
+        """ recursive to_primitive for basic data types. """
+        if isinstance(obj, list):
+            return [cls._to_primitive(e) for e in obj]
+        elif isinstance(obj, dict):
+            return dict(
+                (k, cls._to_primitive(v)) for k, v in obj.items()
+            )
+        else:
+            return str(obj)
+
+    def __hash__(self):
+        if not hasattr(self, "_hash"):
+            if isinstance(self._errors, list):
+                self._hash = hash(tuple(self._errors))
+            if isinstance(self._errors, dict):
+                dict_as_tuple = tuple([
+                    (k, self._errors[k]) for k in sorted(self._errors)
+                ])
+                self._hash = hash(dict_as_tuple)
+        return self._hash
 
 
 @str_compat
@@ -40,9 +104,8 @@ class ErrorMessage(object):
         else:
             return False
 
-
-class BaseError(Exception):
-    pass
+    def __hash__(self):
+        return hash((self.summary, self.type, self.info))
 
 
 @str_compat
@@ -66,54 +129,54 @@ class FieldError(BaseError, Sequence):
                 items = [arg]
         else:
             items = args
-        self.messages = []
+        errors = []
         for item in items:
             if isinstance(item, string_type):
-                self.messages.append(ErrorMessage(item))
+                errors.append(ErrorMessage(item))
             elif isinstance(item, tuple):
-                self.messages.append(ErrorMessage(*item))
+                errors.append(ErrorMessage(*item))
             elif isinstance(item, ErrorMessage):
-                self.messages.append(item)
+                errors.append(item)
             elif isinstance(item, self.__class__):
-                self.messages.extend(item.messages)
+                errors.extend(item.errors)
             else:
                 raise TypeError("'{0}()' object is neither a {1} nor an error message."\
                                 .format(type(item).__name__, type(self).__name__))
-        for message in self.messages:
-            message.type = self.type or type(self)
+        for error in errors:
+            error.type = self.type or type(self)
 
-        super(FieldError, self).__init__(self.messages)
+        super(FieldError, self).__init__(None, errors=errors)
 
     def __eq__(self, other):
         if type(other) is type(self):
-            return other.messages == self.messages
+            return other.errors == self.errors
         elif isinstance(other, list):
-            return other == self.messages
+            return other == self.errors
         return False
 
+    def __hash__(self):
+        return super(FieldError, self).__hash__()
+
     def __contains__(self, value):
-        return value in self.messages
+        return value in self.errors
 
     def __getitem__(self, index):
-        return self.messages[index]
+        return self.errors[index]
 
     def __iter__(self):
-        return iter(self.messages)
+        return iter(self.errors)
 
     def __len__(self):
-        return len(self.messages)
+        return len(self.errors)
 
     def __repr__(self):
-        if len(self.messages) == 1:
-            msg_repr = str(self.messages[0])
+        if len(self.errors) == 1:
+            msg_repr = str(self.errors[0])
         else:
-            msg_repr = '[' + str.join(', ', map(str, self.messages)) + ']'
+            msg_repr = '[' + str.join(', ', map(str, self.errors)) + ']'
         return '%s(%s)' % (self.__class__.__name__, msg_repr)
 
     __str__ = __repr__
-
-    def pop(self, *args):
-        return self.messages.pop(*args)
 
 
 class ConversionError(FieldError, TypeError):
@@ -138,14 +201,12 @@ class CompoundError(BaseError):
     def __init__(self, errors):
         if not isinstance(errors, dict):
             raise TypeError("Compound errors must be reported as a dictionary.")
-        self.errors = {}
         for key, value in errors.items():
             if isinstance(value, CompoundError):
-                self.errors[key] = value.errors
+                errors[key] = value.errors
             else:
-                self.errors[key] = value
-        self.messages = self.errors # v1
-        super(CompoundError, self).__init__(self.errors)
+                errors[key] = value
+        super(CompoundError, self).__init__(None, errors)
 
 
 class DataError(CompoundError):

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -7,7 +7,7 @@ import json
 from collections import Sequence, Mapping
 
 from .common import *
-from .compat import string_type
+from .compat import string_type, str_compat
 from .datastructures import FrozenDict, FrozenList
 
 
@@ -102,7 +102,7 @@ class ErrorMessage(object):
         self.info = info
 
     def __repr__(self):
-        return '%s(%s, %s)' % (
+        return "%s(%s, %s)" % (
             self.__class__.__name__,
             repr(self.summary),
             repr(self.info)
@@ -141,7 +141,6 @@ class ErrorMessage(object):
         return hash((self.summary, self.type, self.info))
 
 
-@str_compat
 class FieldError(BaseError, Sequence):
 
     type = None

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -124,7 +124,11 @@ class ErrorMessage(object):
 
     def __eq__(self, other):
         if isinstance(other, ErrorMessage):
-            return self.__dict__ == other.__dict__
+            return (
+                self.summary == other.summary and
+                self.type == other.type and
+                self.info == other.info
+            )
         elif isinstance(other, string_type):
             return self.summary == other
         else:

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -104,7 +104,7 @@ class ModelMeta(type):
                 attrs[key] = field
 
         klass = type.__new__(mcs, name, bases, attrs)
-        klass = str_compat(klass)
+        klass = str_compat(klass, with_repr=True)
 
         # Parse schema options
         options = mcs._read_options(name, bases, attrs, options_members)

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -7,6 +7,7 @@ import inspect
 from types import FunctionType
 
 from .common import * # pylint: disable=redefined-builtin
+from .compat import str_compat, repr_compat
 from .datastructures import OrderedDict, Context, ChainMap, MappingProxyType
 from .exceptions import *
 from .iteration import atoms
@@ -104,7 +105,7 @@ class ModelMeta(type):
                 attrs[key] = field
 
         klass = type.__new__(mcs, name, bases, attrs)
-        klass = str_compat(klass, with_repr=True)
+        klass = repr_compat(str_compat(klass))
 
         # Parse schema options
         options = mcs._read_options(name, bases, attrs, options_members)

--- a/schematics/role.py
+++ b/schematics/role.py
@@ -1,9 +1,9 @@
-
-from .compat import str_compat
+from .compat import str_compat, repr_compat
 
 import collections
 
 
+@repr_compat
 @str_compat
 class Role(collections.Set):
 

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -56,7 +56,7 @@ def validate(schema, mutable, raw_data=None, trusted_data=None,
         data = import_loop(schema, mutable, raw_data, trusted_data=trusted_data,
             context=context, **kwargs)
     except DataError as exc:
-        errors = exc.errors
+        errors = dict(exc.errors)
         data = exc.partial_data
 
     errors.update(_validate_model(schema, mutable, data, context))

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -56,7 +56,7 @@ def validate(schema, mutable, raw_data=None, trusted_data=None,
         data = import_loop(schema, mutable, raw_data, trusted_data=trusted_data,
             context=context, **kwargs)
     except DataError as exc:
-        errors = exc.messages
+        errors = exc.errors
         data = exc.partial_data
 
     errors.update(_validate_model(schema, mutable, data, context))
@@ -90,7 +90,7 @@ def _validate_model(schema, mutable, data, context):
             schema._validator_functions[field_name](mutable, data, value, context)
         except FieldError as exc:
             serialized_field_name = field.serialized_name or field_name
-            errors[serialized_field_name] = exc.messages
+            errors[serialized_field_name] = exc.errors
             invalid_fields.append(field_name)
 
     for field_name in invalid_fields:
@@ -126,4 +126,3 @@ def prepare_validator(func, argcount):
 
 
 __all__ = module_exports(__name__)
-

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -274,32 +274,30 @@ def test_conversion_with_validation(input, import_, two_pass, input_instance, in
 
     errors = excinfo.value.errors
 
-    err_list = errors.pop('listfield')
+    err_list = errors['listfield']
     assert type(err_list) is ValidationError
     assert len(err_list) == 1
 
-    err_list = errors['modelfield'].pop('listfield')
+    err_list = errors['modelfield']['listfield']
     assert type(err_list) is ValidationError
     assert len(err_list) == 2
 
-    err_list = errors['modelfield']['modelfield'].pop('intfield')
+    err_list = errors['modelfield']['modelfield']['intfield']
     assert len(err_list) == 1
 
     if not partial:
-        err_list = errors['modelfield']['modelfield'].pop('reqfield')
+        err_list = errors['modelfield']['modelfield']['reqfield']
         assert len(err_list) == 1
         if init_to_none:
             partial_data['modelfield']['modelfield'].pop('reqfield')
 
-    err_dict = errors['modelfield']['modelfield'].pop('matrixfield')
-    sub_err_dict = err_dict.pop(1)
+    err_dict = errors['modelfield']['modelfield']['matrixfield']
+    sub_err_dict = err_dict[1]
     assert list((k, type(v)) for k, v in sub_err_dict.items()) \
         == [(2, ValidationError), (3, ValidationError)]
-    assert err_dict == {}
-
-    assert errors['modelfield'].pop('modelfield') == {}
-    assert errors.pop('modelfield') == {}
-    assert errors == {}
+    assert len(err_dict) == 1
+    ##  assert len(errors['modelfield']['modelfield']) == 2
+    assert len(errors['modelfield']) == 2
+    assert len(errors) == 2
 
     assert excinfo.value.partial_data == partial_data
-

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -268,6 +268,8 @@ def test_conversion_with_validation(input, import_, two_pass, input_instance, in
                 m = M(input, init=init)
                 m.validate(partial=partial)
             else:
+                # variant = none
+                # partial = true
                 M(input, init=init, partial=partial, validate=True)
         else:
             input.validate(init_values=init, partial=partial)
@@ -296,7 +298,7 @@ def test_conversion_with_validation(input, import_, two_pass, input_instance, in
     assert list((k, type(v)) for k, v in sub_err_dict.items()) \
         == [(2, ValidationError), (3, ValidationError)]
     assert len(err_dict) == 1
-    ##  assert len(errors['modelfield']['modelfield']) == 2
+    assert len(errors['modelfield']['modelfield']) == 2 + (0 if partial else 1)
     assert len(errors['modelfield']) == 2
     assert len(errors) == 2
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -150,6 +150,11 @@ def test_frozen_dict():
     with pytest.raises(TypeError):
         frozen_dict["bar"] = "baz"
 
+    assert hash(frozen_dict) == hash(FrozenDict({"foo": "bar"}))
+    assert str(frozen_dict) == str({"foo": "bar"}) == repr(frozen_dict)
+    assert list(frozen_dict) == list({"foo": "bar"})
+    assert frozen_dict == {"foo": "bar"}
+
 
 def test_frozen_list():
     frozen_list = FrozenList([0, 1, 2])
@@ -161,3 +166,6 @@ def test_frozen_list():
 
     with pytest.raises(TypeError):
         frozen_list[1] = "baz"
+
+    assert frozen_list == [0, 1, 2]
+    assert frozen_list != [0, 1, 3]

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -137,3 +137,27 @@ def test_context():
     c._setdefaults(FooContext(x=9, z=9))
     assert c.__dict__ == dict(x=1, y=2, z=9)
 
+
+def test_frozen_dict():
+    frozen_dict = FrozenDict({
+        "foo": "bar"
+    })
+    assert frozen_dict["foo"] == "bar"
+    assert len(frozen_dict) == 1
+    with pytest.raises(TypeError):
+        del frozen_dict["foo"]
+
+    with pytest.raises(TypeError):
+        frozen_dict["bar"] = "baz"
+
+
+def test_frozen_list():
+    frozen_list = FrozenList([0, 1, 2])
+    assert frozen_list[0] == 0
+    assert len(frozen_list) == 3
+
+    with pytest.raises(TypeError):
+        del frozen_list[0]
+
+    with pytest.raises(TypeError):
+        frozen_list[1] = "baz"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -60,7 +60,7 @@ def test_error_from_mixed_list():
     assert [msg.info for msg in e.messages] == [99, None, 0, 1]
 
 
-def test_error_repr():
+def test_error_str():
 
     assert str(ValidationError('foo')) == '["foo"]'
 
@@ -71,8 +71,14 @@ def test_error_repr():
 
     assert str(e) == '["foo", "bar: 98", "baz: [1, 2, 3]"]'
 
+
+def test_error_repr():
+
+    e = BaseError({"foo": "bar"})
+    assert repr(e) == "<BaseError: {'foo': 'bar'}>"
+
     e = ValidationError(u'é')
-    assert str(e) == repr(e)
+    assert repr(e) == u'<ValidationError: [ErrorMessage(é)]>'
 
 
 def test_error_list_conversion():
@@ -85,12 +91,6 @@ def test_error_eq():
     assert ValidationError("A") != ConversionError("A")
     assert ValidationError("A", "B") == ValidationError("A", "B") == ["A", "B"]
     assert ValidationError("A") != ValidationError("A", "B")
-
-
-def _test_error_pop():
-    err = ValidationError("A", "B", "C")
-    assert err.pop() == "C"
-    assert err == ValidationError("A", "B")
 
 
 def test_error_message_object():
@@ -120,7 +120,7 @@ def test_error_failures():
 
 
 def test_to_primitive():
-    error = BaseError('', errors={
+    error = BaseError({
         'a': [ErrorMessage('a1'), ErrorMessage('a2')],
         'b': {
             'd': ErrorMessage('d_val'),
@@ -139,7 +139,7 @@ def test_to_primitive():
 
 
 def test_to_primitive_list():
-    error = BaseError(None, errors=[ErrorMessage('a1'), ErrorMessage('a2')])
+    error = BaseError([ErrorMessage('a1'), ErrorMessage('a2')])
     assert error.to_primitive() == ['a1', 'a2']
 
 
@@ -152,12 +152,12 @@ def test_autopopulate_message_on_none():
         },
         'c': ErrorMessage('this is an error')
     }
-    e = BaseError(None, errors)
+    e = BaseError(errors)
     assert str(e) == json.dumps(BaseError._to_primitive(errors))
 
 
 @pytest.mark.parametrize("e", [
-    BaseError("", errors=["a", "b"]),
+    BaseError(["a", "b"]),
     ConversionError(ErrorMessage("foo"), ErrorMessage("bar")),
     CompoundError({"a": ValidationError(ErrorMessage("foo"))})
 ])

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -72,15 +72,6 @@ def test_error_str():
     assert str(e) == '["foo", "bar: 98", "baz: [1, 2, 3]"]'
 
 
-def test_error_repr():
-
-    e = BaseError({"foo": "bar"})
-    assert repr(e) == "<BaseError: {'foo': 'bar'}>"
-
-    e = ValidationError(u'é')
-    assert repr(e) == u'<ValidationError: [ErrorMessage(é)]>'
-
-
 def test_error_list_conversion():
     err = ValidationError("A", "B", "C")
     assert list(err) == err.messages
@@ -99,6 +90,17 @@ def test_error_message_object():
     assert ErrorMessage('foo') != 'bar'
     assert ErrorMessage('foo', 1) == ErrorMessage('foo', 1)
     assert ErrorMessage('foo', 1) != ErrorMessage('foo', 2)
+
+
+@pytest.mark.parametrize("error", [
+    ErrorMessage('foo', info='bar'),
+    BaseError([ErrorMessage('foo', info='bar')]),
+    BaseError({"foo": "bar"}),
+    ValidationError(u'é')
+])
+def test_repr(error):
+    print(repr(error))
+    assert error == eval(repr(error))
 
 
 def test_error_failures():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -95,12 +95,16 @@ def test_error_message_object():
 @pytest.mark.parametrize("error", [
     ErrorMessage('foo', info='bar'),
     BaseError([ErrorMessage('foo', info='bar')]),
-    BaseError({"foo": "bar"}),
-    ValidationError(u'é')
+    BaseError({"foo": "bar"})
 ])
 def test_repr(error):
     print(repr(error))
     assert error == eval(repr(error))
+
+
+def test_error_repr():
+    e = ValidationError(u'é')
+    assert repr(e) == u"ValidationError([ErrorMessage('é', None)])"
 
 
 def test_error_failures():

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -155,7 +155,7 @@ def test_autopopulate_message_on_none():
         'c': ErrorMessage('this is an error')
     }
     e = BaseError(errors)
-    assert str(e) == json.dumps(BaseError._to_primitive(errors))
+    assert json.loads(str(e)) == BaseError._to_primitive(errors)
 
 
 @pytest.mark.parametrize("e", [

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -95,16 +95,12 @@ def test_error_message_object():
 @pytest.mark.parametrize("error", [
     ErrorMessage('foo', info='bar'),
     BaseError([ErrorMessage('foo', info='bar')]),
-    BaseError({"foo": "bar"})
+    BaseError({"foo": "bar"}),
+    ErrorMessage(u'é'),
+    ValidationError(u'é')
 ])
-def test_repr(error):
-    print(repr(error))
+def test_exception_repr(error):
     assert error == eval(repr(error))
-
-
-def test_error_repr():
-    e = ValidationError(u'é')
-    assert repr(e) == u"ValidationError([ErrorMessage('é', None)])"
 
 
 def test_error_failures():


### PR DESCRIPTION
This PR attempts to address a few issues around exceptions:

#452: all exceptions are now hashable and immutable
#445: exceptions now have a human readable message, and a to_primitive function is provided to for serialization in markup (e.g. json)
#369: conforms to PEP-352, and normalizes all exceptions to a message and an errors field.

This PR has a backward-incompatible change of FieldErrors no longer being mutable, which I'm amenable to. FieldError.pop() is removed as a result.

