### PR TITLE
Add MACAddressType

### DIFF
--- a/schematics/types/net.py
+++ b/schematics/types/net.py
@@ -82,6 +82,33 @@ class IPv6Type(IPAddressType):
         return '.'.join(str(random.randrange(256)) for _ in range(4))
 
 
+### MAC address
+
+class MACAddressType(StringType):
+
+    REGEX = re.compile(r"""
+                         (
+                             ^([0-9a-f]{2}[-]){5}([0-9a-f]{2})$
+                            |^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$
+                            |^([0-9a-f]{12})
+                            |^([0-9a-f]{6}[-:]([0-9a-f]{6}))$
+                            |^([0-9a-f]{4}(\.[0-9a-f]{4}){2})$
+                         )
+                         """, re.I + re.X)
+
+    def _mock(self, context=None):
+        return ':'.join(random.choice('0123456789abcdef')+random.choice('0123456789abcdef')
+                        for _ in range(6))
+
+    def validate_(self, value, context=None):
+        if not bool(self.REGEX.match(value)):
+            raise ValidationError('Invalid MAC address')
+
+    def to_primitive(self, value, context=None):
+        value = value.replace(':', '').replace('.', '').replace('-', '')
+        return ':'.join(value[i:i+2] for i in range(0, len(value), 2))
+
+
 ### URI patterns
 
 GEN_DELIMS = set(':/?#[]@')

--- a/tests/test_types_net.py
+++ b/tests/test_types_net.py
@@ -47,6 +47,38 @@ def test_ip_type():
     assert IPAddressType().validate('fe80::223:6caf:fe76:c12d')
 
 
+def test_mac_type():
+    addrs = [
+        '00-00-00-00-00-00',
+        '03:0F:25:B7:10:1E',
+        '030F25B7104E',
+        '030F25:B7104E',
+        '030F25-B7104E',
+        '030F.25B7.104E',
+    ]
+    for addr in addrs:
+        assert MACAddressType().validate(addr)
+
+    addrs = [
+        '00-00-00-00-00',
+        '00:00-00-00-00-00',
+        '00:00-00-00-00-00',
+        '030F25B7104',
+        '030F25B7104Z',
+        '30F25:B7104E',
+        '030F2-B7104E',
+        '030F:25B7.104E',
+    ]
+    for addr in addrs:
+        with pytest.raises(ValidationError):
+            MACAddressType().validate(addr)
+
+    mock = MACAddressType(required=True).mock()
+    assert MACAddressType().validate(mock)
+
+    s = MACAddressType().to_primitive(value='00-00-00-00-00-00')
+    assert MACAddressType().validate(s)
+
 def test_url_type_with_valid_urls():
 
     field = URLType()


### PR DESCRIPTION
Schematics is an excellent library. 
This PR adds support for MACAddressType.
There are several formats: 
'08:00:2b:01:02:03'
'08-00-2b-01-02-03'
'08002b:010203'
'08002b-010203'
'0800.2b01.0203'
'08002b010203'
All of these formats are well understood by postgres and i stole them from the postgres documentation. 
Schematics can support mac addresses out of the box
