### PR TITLE
dictionary-named methods are raising a validation exception

### DIFF
--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -1,4 +1,3 @@
-
 from .compat import iteritems
 from .undefined import Undefined
 from collections import namedtuple
@@ -44,9 +43,7 @@ def atoms(schema, mapping, keys=Atom._fields, filter=None):
 
         if has_value:
             try:
-                value = getattr(mapping, field_name)
-            except AttributeError:
-                value = mapping.get(field_name, Undefined)
+                value = mapping[field_name]
             except Exception:
                 value = Undefined
 


### PR DESCRIPTION
There's currently a bug where naming fields of a model after the dictionary methods will raise an incorrect DataError during validation (see unit test or https://github.com/toumorokoshi/transmute-core/issues/20)

Looking at the documentation, the atoms() method shouldn't support anything besides a mapping anyway. This builds off of that assumption, and removes the getattr call.