### PR TITLE
Do not call field validator if field has not been set

### DIFF
--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -84,11 +84,10 @@ def _validate_model(schema, mutable, data, context):
     errors = {}
     invalid_fields = []
 
-    has_validator = lambda atom: atom.name in schema._validator_functions
+    has_validator = lambda atom: atom.value is not Undefined and atom.name in schema._validator_functions
     for field_name, field, value in atoms(schema, data, filter=has_validator):
         try:
-            if field_name in data:
-                schema._validator_functions[field_name](mutable, data, value, context)
+            schema._validator_functions[field_name](mutable, data, value, context)
         except (FieldError, DataError) as exc:
             serialized_field_name = field.serialized_name or field_name
             errors[serialized_field_name] = exc.errors

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -87,7 +87,8 @@ def _validate_model(schema, mutable, data, context):
     has_validator = lambda atom: atom.name in schema._validator_functions
     for field_name, field, value in atoms(schema, data, filter=has_validator):
         try:
-            schema._validator_functions[field_name](mutable, data, value, context)
+            if field_name in data:
+                schema._validator_functions[field_name](mutable, data, value, context)
         except (FieldError, DataError) as exc:
             serialized_field_name = field.serialized_name or field_name
             errors[serialized_field_name] = exc.errors


### PR DESCRIPTION
It seems there is a regression between 2.0.0a1 and 2.0.1 regarding fileld validators.

* In 2.0.0a1, field validator functions were called on model validation only when the corresponding field was given a value.
* In 2.0.1 it seems that field validators are called no matter what, and the `data` array passed to the validator function is missing entry for the field it is supposed to validate...

```python
#!/usr/bin/env python

from schematics.models import Model
from schematics.types import StringType
from schematics.exceptions import DataError, ValidationError


class FooBar(Model):
    foo = StringType(required=True)
    bar = StringType()

    def validate_foo(self, data, value):
        print '>>>>>> testing foo, data=', data
        if data['foo'] and 'foo' not in data['foo']:
            raise ValidationError('Illegal value')

if __name__ == '__main__':
    print "===== fb1"
    try:
        fb1 = FooBar({})
        fb1.validate()
    except DataError as e:
        print "===== fb1 FAILED", e
    else:
        print "===== fb1 OK"

    print "===== fb2"
    try:
        fb2 = FooBar({'foo': 'foobar'})
        fb2.validate()
    except DataError as e:
        print "===== fb2 FAILED", e
    else:
        print "===== fb2 OK"

    print "===== fb3"
    try:
        fb3 = FooBar({'foo': 'bar'})
        fb3.validate()
    except DataError as e:
        print "===== fb3 FAILED", e
    else:
        print "===== fb3 OK"
```
Output in 2.0.0a1:
```
===== fb1
===== fb1 FAILED {'foo': ConversionError("This field is required.")}
===== fb2
>>>>>> testing foo, data= {'foo': u'foobar', 'bar': None}
===== fb2 OK
===== fb3
>>>>>> testing foo, data= {'foo': u'bar', 'bar': None}
===== fb3 FAILED {'foo': [ErrorMessage("Illegal value")]}
```

Output in 2.0.1:
```
===== fb1
>>>>>> testing foo, data= {'bar': None}
Traceback (most recent call last):
  File "./foobar.py", line 21, in <module>
    fb1.validate()
  File "/home/christian/.virtualenvs/schematics201/local/lib/python2.7/site-packages/schematics/models.py", line 254, in validate
    partial=partial, convert=convert, app_data=app_data, **kwargs)
  File "/home/christian/.virtualenvs/schematics201/local/lib/python2.7/site-packages/schematics/models.py", line 295, in _convert
    return func(self._schema, self, raw_data=raw_data, oo=True, context=context, **kwargs)
  File "/home/christian/.virtualenvs/schematics201/local/lib/python2.7/site-packages/schematics/validate.py", line 62, in validate
    errors.update(_validate_model(schema, mutable, data, context))
  File "/home/christian/.virtualenvs/schematics201/local/lib/python2.7/site-packages/schematics/validate.py", line 90, in _validate_model
    schema._validator_functions[field_name](mutable, data, value, context)
  File "/home/christian/.virtualenvs/schematics201/local/lib/python2.7/site-packages/schematics/validate.py", line 123, in newfunc
    return func(*args, **kwargs)
  File "./foobar.py", line 14, in validate_foo
    if data['foo'] and 'foo' not in data['foo']:
KeyError: 'foo'
```

----

It looks like it was introduced by the rewriting needed to merge PR#441:
- Support for raising DataError inside custom validate_fieldname methods.
   `#441 <https://github.com/schematics/schematics/pull/441>`__
   (`alexhayes <https://github.com/alexhayes>`__)

before that, validator function was called when defined and when `field_name` is in `data`, after that the second condition is dropped.
