### PR TITLE
Add EnumType

### DIFF
--- a/schematics/contrib/enum_type.py
+++ b/schematics/contrib/enum_type.py
@@ -1,0 +1,79 @@
+"""Type supporting native Python3 enum. It depends either on Py3.4+ or e.g. enum34.
+"""
+from __future__ import unicode_literals, absolute_import
+
+try:
+    from enum import Enum
+except ImportError:
+    pass
+
+from ..exceptions import ConversionError
+from ..translator import _
+from ..types import BaseType
+from ..compat import string_type
+
+
+class EnumType(BaseType):
+    """A field type allowing to use native enums as values.
+    Restricts values to enum members and (optionally) enum values.
+    `use_values` - if set to True allows do assign enumerated values to the field.
+
+    >>> import enum
+    >>> class E(enum.Enum):
+    ...    A = 1
+    ...    B = 2
+    >>> from schematics import Model
+    >>> class AModel(Model):
+    ...    foo = EnumType(E)
+    >>> a = AModel()
+    >>> a.foo = E.A
+    >>> a.foo.value == 1
+    """
+    MESSAGES = {
+        'convert': _("Couldn't interpret '{0}' as member of {1}."),
+    }
+
+    def __init__(self, enum, use_values=False, **kwargs):
+        """
+        :param enum: Enum class to which restrict values assigned to the field.
+        :param use_values: If true, also values of the enum (right-hand side) can be assigned here.
+        Other args are passed to superclass.
+        """
+        self._enum_class = enum
+        self._use_values = use_values
+        super(EnumType, self).__init__(**kwargs)
+
+    def to_native(self, value, context=None):
+        if isinstance(value, self._enum_class):
+            return value
+        else:
+            by_name = self._find_by_name(value)
+            if by_name:
+                return by_name
+            by_value = self._find_by_value(value)
+            if by_value:
+                return by_value
+        raise ConversionError(self.messages['convert'].format(value, self._enum_class))
+
+    def _find_by_name(self, value):
+        if isinstance(value, string_type):
+            try:
+                return self._enum_class[value]
+            except KeyError:
+                pass
+
+    def _find_by_value(self, value):
+        if not self._use_values:
+            return
+        for member in self._enum_class:
+            if member.value == value:
+                return member
+
+    def to_primitive(self, value, context=None):
+        if isinstance(value, Enum):
+            if self._use_values:
+                return value.value
+            else:
+                return value.name
+        else:
+            return str(value)

--- a/tests/test_enum_type.py
+++ b/tests/test_enum_type.py
@@ -1,0 +1,59 @@
+import pytest
+
+from schematics.contrib.enum_type import EnumType
+from schematics.exceptions import ConversionError
+
+try:
+    from enum import Enum
+
+
+    class E(Enum):
+        A = 1
+        B = 'b'
+
+
+    class F(Enum):
+        A = 1
+        B = 1
+
+except ImportError:
+    Enum = None
+
+pytestmark = pytest.mark.skipif(Enum is None,
+                                reason='requires enum')
+
+
+def test_to_native_by_name():
+    field = EnumType(E)
+    assert field.to_native("A") == E.A
+    assert field.to_native("B") == E.B
+    with pytest.raises(ConversionError):
+        field.to_native("a")
+
+
+def test_to_native_by_value():
+    field = EnumType(E, use_values=True)
+    assert field.to_native(1) == E.A
+    assert field.to_native("b") == field.to_native("B")
+    with pytest.raises(ConversionError):
+        field.to_native(2)
+
+
+def test_to_native_by_value_duplicate():
+    field = EnumType(F, use_values=True)
+    assert field.to_native(1) == F.A
+
+
+def test_passthrough():
+    field = EnumType(E, use_values=True)
+    assert field.to_native(E.A) == E.A
+
+
+def test_to_primitive_by_name():
+    field = EnumType(E, use_values=False)
+    assert field.to_primitive(E.A) == "A"
+
+
+def test_to_primitive_by_value():
+    field = EnumType(E, use_values=True)
+    assert field.to_primitive(E.A) == 1


### PR DESCRIPTION
This PR adds native Py3 enum type. Main reason is to limit possible values to enumerated ones, while `to_native` returns enum instances not strings.