### PR TITLE
Feature/allow custom options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/_build
 .coverage
 *.sqlite3
 /.idea
+/.venv

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/_build
 /.cache
 .coverage
 *.sqlite3
+/.idea

--- a/schematics/schema.py
+++ b/schematics/schema.py
@@ -32,7 +32,7 @@ class Schema(object):
 class SchemaOptions(object):
 
     def __init__(self, namespace=None, roles=None, export_level=DEFAULT,
-            serialize_when_none=None, export_order=False):
+            serialize_when_none=None, export_order=False, **kwargs):
         self.namespace = namespace
         self.roles = roles or {}
         self.export_level = export_level
@@ -41,6 +41,9 @@ class SchemaOptions(object):
         elif serialize_when_none is False:
             self.export_level = NONEMPTY
         self.export_order = export_order
+
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def __iter__(self):
         for key, value in inspect.getmembers(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -343,14 +343,14 @@ def test_good_options_args():
     assert mo.roles == {}
 
 
-def test_bad_options_args():
+def test_kwargs_options_args():
     args = {
         'roles': None,
-        'badkw': None,
+        'foo': 'bar',
     }
 
-    with pytest.raises(TypeError):
-        ModelOptions(**args)
+    mo = ModelOptions(**args)
+    assert mo.foo == 'bar'
 
 
 def test_no_options_args():


### PR DESCRIPTION
I think Model's Options should allow defining custom options without having to derive a new class from `SchemaOptions` and specifying `__optionsclass__` which is an unnecessary hassle...

The docs actually provide the following example ([see here](http://schematics.readthedocs.io/en/latest/usage/models.html#model-configuration)):
```
class Whatever(Model):
    ...
    class Options:
        option = value
```

Why not support it?  it's a lot nicer and straightforward than:
```
class MyOptions(SchemaOption):
  def __init(foo=None, **kwargs):
    super(MyOptions, self).__init__(**kwargs)
    self.foo = foo

class Whatever(Model):
  __optionsclass__ = MyOptions
  class Options:
    foo = "Bar"
```