### PR TITLE
Make role send more parameters and allow serialize send a callable role

### DIFF
--- a/schematics/role.py
+++ b/schematics/role.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .compat import str_compat, repr_compat
 
 import collections
@@ -57,8 +59,13 @@ class Role(collections.Set):
         return self._from_iterable(fields)
 
     # apply role to field
-    def __call__(self, name, value):
-        return self.function(name, value, self.fields)
+    def __call__(self, schema, name, value):
+        try:
+            return self.function(schema, name, value, self.fields)
+        except TypeError:
+            warnings.warn('You have a role/filter function which uses a deprecated signature. '
+                          'It should be schema, field_name and value.')
+            return self.function(name, value, self.fields)
 
     # static filter functions
     @staticmethod

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -729,7 +729,7 @@ def test_new_role_signature():
     a = NewRole(dict(id='a id', name='a name'))
     a.serialize(role='public')
     assert new_role.call_count == 2
-    for i, args in enumerate([('id', 'a id', {'id', 'name'}), ('name', 'a name', {'id', 'name'})]):
+    for i, args in enumerate([('id', 'a id', set(['id', 'name'])), ('name', 'a name', set(['id', 'name']))]):
         call = new_role.call_args_list[i][0]
         assert call[0].name == NewRole.__name__
         assert call[1:] == args
@@ -738,7 +738,8 @@ def test_new_role_signature():
     a.serialize(role='public')
     assert old_role.call_count == 4
     # Ignore new calls
-    for i, args in enumerate(['ignore', ('id', 'a id', {'id', 'name'}), 'ignore', ('name', 'a name', {'id', 'name'})]):
+    for i, args in enumerate(
+            ['ignore', ('id', 'a id', set(['id', 'name'])), 'ignore', ('name', 'a name', set(['id', 'name']))]):
         if args == 'ignore':
             continue
         call = old_role.call_args_list[i][0]


### PR DESCRIPTION
This helps when you have cases where you don't know at the definition
of the class which fields should be shown, for example an ACL which
requires a logged in user which could be sent as callable role to
serialize