### PR TITLE
Minor number types refactor

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -449,7 +449,10 @@ class NumberType(BaseType):
         super(NumberType, self).__init__(**kwargs)
 
     def _mock(self, context=None):
-        return get_value_in(self.min_value, self.max_value)
+        number = random.uniform(
+            *get_range_endpoints(self.min_value, self.max_value)
+        )
+        return self.native_type(number) if self.native_type else number
 
     def to_native(self, value, context=None):
         if isinstance(value, bool):

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -37,12 +37,9 @@ def fill_template(template, min_length, max_length):
 
 
 def get_range_endpoints(min_length, max_length, padding=0, required_length=0):
-    if min_length is None and max_length is None:
+    if min_length is None:
         min_length = 0
-        max_length = 16
-    elif min_length is None:
-        min_length = 0
-    elif max_length is None:
+    if max_length is None:
         max_length = max(min_length * 2, 16)
 
     if padding:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -233,7 +233,7 @@ def test_number_mock(field_type, min_value, max_value):
 
 
 @pytest.mark.parametrize('field_type,value,primitive', [
-    (DecimalType, Decimal('1.3'), '1.3'),
+    (DecimalType, Decimal('1.3'), u'1.3'),
     (FloatType, 1.3, 1.3),
     (IntType, 13, 13),
 ])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -215,6 +215,19 @@ def test_float():
         f(_uuid)
 
 
+@pytest.mark.parametrize('field_type,min_value,max_value', [
+    (IntType, 0, 10),
+    (FloatType, -1.3, 4.5),
+])
+def test_number_mock(field_type, min_value, max_value):
+    field = field_type(
+        required=True, min_value=min_value, max_value=max_value
+    )
+    mock = field.mock()
+    assert type(mock) is field_type.native_type
+    field.validate(mock)
+
+
 def test_int_validation():
     with pytest.raises(ConversionError):
         IntType().validate('foo')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -135,27 +135,16 @@ def test_datetime_accepts_datetime():
 def test_int():
     intfield = IntType()
     i = lambda x: (intfield(x), type(intfield(x)))
-    # from int
-    assert i(3) == (3, int)
-    # from bool
-    assert i(True) == (1, int)
-    # from float
-    assert i(3.0) == (3, int)
     with pytest.raises(ConversionError):
         i(3.2)
-    # from string
-    assert i("3") == (3, int)
     with pytest.raises(ConversionError):
         i("3.0")
     with pytest.raises(ConversionError):
         i("a")
     # from decimal
-    assert i(Decimal("3")) == (3, int)
-    assert i(Decimal("3.0")) == (3, int)
     with pytest.raises(ConversionError):
         i(Decimal("3.2"))
     # from fraction
-    assert i(Fraction(30, 10)) == (3, int)
     with pytest.raises(ConversionError):
         i(Fraction(7, 2))
     # from uuid
@@ -193,31 +182,46 @@ def test_int_strict():
 def test_float():
     floatfield = FloatType()
     f = lambda x: (floatfield(x), type(floatfield(x)))
-    # from int
-    assert f(3) == (3.0, float)
-    # from bool
-    assert f(True) == (1.0, float)
-    # from float
-    assert f(3.2) == (3.2, float)
-    # from string
-    assert f("3") == (3.0, float)
-    assert f("3.2") == (3.2, float)
-    assert f("3.210987e6") == (3210987, float)
     with pytest.raises(ConversionError):
         f("a")
-    # from decimal
-    assert f(Decimal("3")) == (3.0, float)
-    assert f(Decimal("3.2")) == (3.2, float)
-    # from fraction
-    assert f(Fraction(7, 2)) == (3.5, float)
     # from uuid
     with pytest.raises(ConversionError):
         f(_uuid)
 
 
+@pytest.mark.parametrize('field_type,raw,expected', [
+    (DecimalType, 0.3, Decimal('0.3')),
+    (DecimalType, Decimal('0.'+10*'9'), Decimal('0.'+10*'9')),
+    (DecimalType, False, Decimal(0)),
+    (FloatType, '-1.3', -1.3),
+    (FloatType, '3', 3.0),
+    (FloatType, '3.2', 3.2),
+    (FloatType, '3.210987e6', 3210987.0),
+    (FloatType, 3, 3.0),
+    (FloatType, 3.2, 3.2),
+    (FloatType, Decimal("3"), 3.0),
+    (FloatType, Decimal("3.2"), 3.2),
+    (FloatType, Fraction(7, 2), 3.5),
+    (FloatType, True, 1.0),
+    (IntType, '32', 32),
+    (IntType, 0.0, 0),
+    (IntType, 3, 3),
+    (IntType, Decimal("3"), 3),
+    (IntType, Decimal("3.0"), 3),
+    (IntType, False, 0),
+    (IntType, Fraction(30, 10), 3),
+    (IntType, True, 1),
+])
+def test_number_to_native(field_type, raw, expected):
+    field = field_type()
+    got = field.to_native(raw)
+    assert (got, type(got)) == (expected, type(expected))
+
+
 @pytest.mark.parametrize('field_type,min_value,max_value', [
-    (IntType, 0, 10),
+    (DecimalType, 1.3, 3.7),
     (FloatType, -1.3, 4.5),
+    (IntType, 0, 10),
 ])
 def test_number_mock(field_type, min_value, max_value):
     field = field_type(


### PR DESCRIPTION
* improved float mocking, which should have resolve #463 
* DecimalType now inherits after NumberType class - beside deduplication it should improve consistency among number types
* added some parametrized tests, including ones for DecimalType which seem to have been untested so far