### PR TITLE
Enable PolyModelType recursive validation

### DIFF
--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -373,16 +373,18 @@ class PolyModelType(CompoundType):
 
         if value is None:
             return None
-        if self.is_allowed_model(value):
-            return value
-        if not isinstance(value, dict):
-            if len(self.model_classes) > 1:
-                instanceof_msg = 'one of: {}'.format(', '.join(
-                    cls.__name__ for cls in self.model_classes))
-            else:
-                instanceof_msg = self.model_classes[0].__name__
-            raise ConversionError(_('Please use a mapping for this field or '
-                                    'an instance of {}').format(instanceof_msg))
+
+        if not context.validate:
+            if self.is_allowed_model(value):
+                return value
+            if not isinstance(value, dict):
+                if len(self.model_classes) > 1:
+                    instanceof_msg = 'one of: {}'.format(', '.join(
+                        cls.__name__ for cls in self.model_classes))
+                else:
+                    instanceof_msg = self.model_classes[0].__name__
+                raise ConversionError(_('Please use a mapping for this field or '
+                                        'an instance of {}').format(instanceof_msg))
 
         model_class = self.find_model(value)
         return model_class(value, context=context)

--- a/tests/test_polymodeltype.py
+++ b/tests/test_polymodeltype.py
@@ -1,6 +1,6 @@
 import pytest
 
-from schematics.models import Model
+from schematics.models import Model, DataError
 from schematics.types import StringType
 from schematics.types.compound import PolyModelType, ListType
 from schematics.util import get_all_subclasses
@@ -14,6 +14,7 @@ class Aaa(A):
 
 class B(A):
     stringB = StringType()
+    regexp_test = StringType(regex='^[0-9]$', required=False)
     @classmethod
     def _claim_polymorphic(cls, data):
         return data.get('stringB') == 'bbb'
@@ -130,3 +131,13 @@ def test_specify_model_by_name():
     assert M.single.is_allowed_model(M())
     assert M.multi.is_allowed_model(M())
     assert M.nested.field.field.is_allowed_model(M())
+
+
+def test_validate_recursively():
+    # Should validate
+    foo = Foo({'strict': {'stringB': 'bbb', 'regexp_test': '1'}})
+    foo.validate()
+
+    foo = Foo({'strict': {'stringB': 'bbb', 'regexp_test': 'a'}})
+    with pytest.raises(DataError):
+        foo.validate()


### PR DESCRIPTION
Please note this tries to fix this bug: When using `PolyModelType` and you `.validate()` on the parent model the validation was not recursive.
