### PR TITLE
Implement TimedeltaType

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -966,8 +966,7 @@ class TimestampType(DateTimeType):
         else:
             value = value.astimezone(self.UTC)
         delta = value - self.EPOCH
-        ts = (delta.days * 24 * 3600) + delta.seconds + delta.microseconds / 1E6
-        return ts
+        return delta.total_seconds()
 
 
 class TimedeltaType(BaseType):

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -29,7 +29,8 @@ __all__ = [
     'BaseType', 'UUIDType', 'StringType', 'MultilingualStringType',
     'NumberType', 'IntType', 'LongType', 'FloatType', 'DecimalType',
     'HashType', 'MD5Type', 'SHA1Type', 'BooleanType', 'GeoPointType',
-    'DateType', 'DateTimeType', 'UTCDateTimeType', 'TimestampType']
+    'DateType', 'DateTimeType', 'UTCDateTimeType', 'TimestampType',
+    'TimedeltaType']
 
 
 def fill_template(template, min_length, max_length):
@@ -68,6 +69,7 @@ def get_value_in(min_length, max_length, padding=0, required_length=0):
 
 
 _alphanumeric = string.ascii_letters + string.digits
+
 
 def random_string(length, chars=_alphanumeric):
     return ''.join(random.choice(chars) for _ in range(length))
@@ -351,7 +353,6 @@ class UUIDType(BaseType):
     MESSAGES = {
         'convert': _("Couldn't interpret '{0}' value as UUID."),
     }
-
 
     def __init__(self, **kwargs):
         # type: (...) -> uuid.UUID
@@ -967,6 +968,38 @@ class TimestampType(DateTimeType):
         delta = value - self.EPOCH
         ts = (delta.days * 24 * 3600) + delta.seconds + delta.microseconds / 1E6
         return ts
+
+
+class TimedeltaType(BaseType):
+
+    """Converts Python Timedelta objects into the corresponding value in seconds.
+    """
+
+    primitive_type = float
+    native_type = datetime.timedelta
+
+    MESSAGES = {
+        'convert': _("Couldn't interpret '{0}' value as Timedelta."),
+    }
+
+    def __init__(self, formats=None, **kwargs):
+        # type: (...) -> datetime.timedelta
+        super(TimedeltaType, self).__init__(**kwargs)
+
+    def _mock(self, context=None):
+        return datetime.timedelta(seconds=random.random() * 1000)
+
+    def to_native(self, value, context=None):
+        if isinstance(value, datetime.timedelta):
+            return value
+
+        try:
+            return datetime.timedelta(seconds=value)
+        except (ValueError, TypeError):
+            raise ConversionError(self.messages['convert'].format(value))
+
+    def to_primitive(self, value, context=None):
+        return value.total_seconds()
 
 
 class GeoPointType(BaseType):

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -993,7 +993,7 @@ class TimedeltaType(BaseType):
             return value
 
         try:
-            return datetime.timedelta(seconds=value)
+            return datetime.timedelta(seconds=float(value))
         except (ValueError, TypeError):
             raise ConversionError(self.messages['convert'].format(value))
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -118,6 +118,9 @@ def test_parse_from_timestamp():
     dt = field.to_native('1446991200.7777')
     assert dt == datetime(2015, 11, 8, 14, 00, microsecond=777700)
 
+    dt = field.to_native(1446991200.7777)
+    assert dt == datetime(2015, 11, 8, 14, 00, microsecond=777700)
+
 
 def test_parse_using_formats():
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -132,6 +132,39 @@ def test_datetime_accepts_datetime():
     assert dt_type.to_primitive(dt) == output
 
 
+def test_timedelta():
+    type_ = TimedeltaType()
+    delta = datetime.timedelta(seconds=10)
+    assert type_(delta.total_seconds()) == delta
+
+
+@pytest.mark.parametrize('value', (
+    42.42,
+    10000,
+    0,
+))
+def test_timedelta_to_native_valid_conversion(value):
+    type_ = TimedeltaType()
+    assert type_.to_native(value) == datetime.timedelta(seconds=value)
+
+
+@pytest.mark.parametrize('value', (
+    'foo',
+    '42.42',
+    [],
+))
+def test_timedelta_to_native_invalid_conversion(value):
+    type_ = TimedeltaType()
+    with pytest.raises(ConversionError):
+        type_.to_native(value)
+
+
+def test_timedelta_mock():
+    type_ = TimedeltaType()
+    mocked = type_.mock()
+    assert isinstance(mocked, datetime.timedelta)
+
+
 def test_int():
     intfield = IntType()
     i = lambda x: (intfield(x), type(intfield(x)))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -140,17 +140,17 @@ def test_timedelta():
 
 @pytest.mark.parametrize('value', (
     42.42,
+    '42.42',
     10000,
     0,
 ))
 def test_timedelta_to_native_valid_conversion(value):
     type_ = TimedeltaType()
-    assert type_.to_native(value) == datetime.timedelta(seconds=value)
+    assert type_.to_native(value) == datetime.timedelta(seconds=float(value))
 
 
 @pytest.mark.parametrize('value', (
     'foo',
-    '42.42',
     [],
 ))
 def test_timedelta_to_native_invalid_conversion(value):
@@ -161,7 +161,7 @@ def test_timedelta_to_native_invalid_conversion(value):
 
 def test_timedelta_mock():
     type_ = TimedeltaType()
-    mocked = type_.mock()
+    mocked = type_._mock()
     assert isinstance(mocked, datetime.timedelta)
 
 


### PR DESCRIPTION
Implements https://github.com/schematics/schematics/issues/539

Implement a TimeDeltaType matching native`datetime.timedelta` type.

Also simplifies `TimeStampType.to_native` call.