### PR TITLE
Set default when value is None

### DIFF
--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -134,6 +134,10 @@ def import_loop(schema, mutable, raw_data=None, field_converter=None, trusted_da
         if value is Undefined and context.init_values:
             value = None
 
+
+        if context.apply_defaults and value is None and field.default is not Undefined:
+            value = field.default
+
         if got_data:
             if field.is_compound:
                 if context.trusted_data and context.recursive:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -116,6 +116,17 @@ def test_defaults():
     assert m._data == {'d0': 0, 'dN': None}
 
 
+    m = M({'d0': None}, apply_defaults=True)
+    assert m._data == {'d0': 0, 'dN': None}
+    m.validate()
+    assert m._data == {'d0': 0, 'dN': None}
+
+    m = M({'d0': None}, apply_defaults=False)
+    assert m._data == {'d0': None, 'dN': None}
+    m.validate()
+    assert m._data == {'d0': None, 'dN': None}
+
+
 def test_invalid_model_fail_validation():
     class Player(Model):
         name = StringType(required=True)


### PR DESCRIPTION
Resolves #548 

## Added: 
This will set a field to its default value when the field is passed into the instance with a value of `None`.
### For example:
```python
class M(Model):
    field = StringValue(default=0)
    field_two = StringValue()
```

__Past behavior__:
```python
m = M({'field': None, 'field_two': None})
m.field
>>> None
m.field_two
>>> None
```

__PR Update__: 
```python
m = M({'field': None, 'field_two': None})
m.field
>>> 0
m.field_two
>>> None
```
### Use Case:
This allows web requests to be parsed easily by passing a dictionary request into the model, and ensuring that the default values will be set.