### PR TITLE
 #593: Update error message for incorrect choices field

### DIFF
--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -165,7 +165,7 @@ class BaseType(object):
 
     MESSAGES = {
         'required': _("This field is required."),
-        'choices': _("Value must be one of {0}."),
+        'choices': _("Value ({0}) must be one of {1}."),
     }
 
     EXPORT_METHODS = {
@@ -332,7 +332,7 @@ class BaseType(object):
     def validate_choices(self, value, context):
         if self.choices is not None:
             if value not in self.choices:
-                raise ValidationError(self.messages['choices'].format(str(self.choices)))
+                raise ValidationError(self.messages['choices'].format(str(value), str(self.choices)))
 
     def mock(self, context=None):
         if not self.required and not random.choice([True, False]):


### PR DESCRIPTION
Added actual `value` into choices error message. Seems like that It's useful to know what value was passed and caused an exception.


Example:
```python
from schematics import Model
from schematics.types import StringType


class MyModel(Model):
    x = StringType(required=True, choices=["a", "b", "c"])


model = MyModel({"x": "d"})
model.validate()
```

Before fix:
`schematics.exceptions.DataError: {"x": ["Value must be one of ['a', 'b', 'c']."]}`

After fix:
`schematics.exceptions.DataError: {"x": ["Value (d) must be one of ['a', 'b', 'c']."]}`

Resolves  #593