### PR TITLE
Avoid some deprecation warnings when using Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 
 matrix:
   include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: TOX_ENV=py37
     - python: 3.6
       env: TOX_ENV=py36
     - python: 2.7

--- a/schematics/datastructures.py
+++ b/schematics/datastructures.py
@@ -2,9 +2,14 @@
 # pylint: skip-file
 
 from __future__ import unicode_literals, absolute_import
-from collections import Mapping, Sequence
 
 from .compat import *
+
+try:
+    from collections.abc import Mapping, Sequence  # PY3
+except ImportError:
+    from collections import Mapping, Sequence  # PY2
+
 
 __all__ = []
 

--- a/schematics/exceptions.py
+++ b/schematics/exceptions.py
@@ -4,12 +4,16 @@ from __future__ import unicode_literals, absolute_import
 
 import json
 
-from collections import Sequence, Mapping
-
-from .translator import LazyText
 from .common import *
 from .compat import string_type, str_compat
 from .datastructures import FrozenDict, FrozenList
+from .translator import LazyText
+
+try:
+    from collections.abc import Mapping, Sequence  # PY3
+except ImportError:
+    from collections import Mapping, Sequence  # PY2
+
 
 __all__ = [
     'BaseError', 'ErrorMessage', 'FieldError', 'ConversionError',

--- a/schematics/role.py
+++ b/schematics/role.py
@@ -1,11 +1,14 @@
-import collections
-
 from .compat import str_compat, repr_compat
+
+try:
+    from collections.abc import Set  # PY3
+except ImportError:
+    from collections import Set  # PY2
 
 
 @repr_compat
 @str_compat
-class Role(collections.Set):
+class Role(Set):
 
     """
     A ``Role`` object can be used to filter specific fields against a sequence.

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -2,10 +2,6 @@
 
 from __future__ import unicode_literals, absolute_import
 
-try:
-    import typing
-except ImportError:
-    pass
 
 import copy
 import datetime
@@ -16,7 +12,7 @@ import random
 import re
 import string
 import uuid
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
 
 from ..common import *
 from ..exceptions import *
@@ -24,6 +20,17 @@ from ..translator import _
 from ..undefined import Undefined
 from ..util import listify
 from ..validate import prepare_validator, get_validation_context
+
+try:
+    import typing
+except ImportError:
+    pass
+
+try:
+    from collections.abc import Iterable  # PY3
+except ImportError:
+    from collections import Iterable  # PY2
+
 
 __all__ = [
     'BaseType', 'UUIDType', 'StringType', 'MultilingualStringType',

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -2,14 +2,6 @@
 
 from __future__ import unicode_literals, absolute_import
 
-try:
-    import typing
-except ImportError:
-    pass
-else:
-    T = typing.TypeVar("T")
-
-from collections import Iterable, Sequence, Mapping
 import itertools
 
 from ..common import *
@@ -20,8 +12,19 @@ from ..transforms import (
     to_native_converter, to_primitive_converter)
 from ..translator import _
 from ..util import get_all_subclasses, import_string
-
 from .base import BaseType, get_value_in
+
+try:
+    import typing
+except ImportError:
+    pass
+else:
+    T = typing.TypeVar("T")
+
+try:
+    from collections.abc import Iterable, Sequence, Mapping  # PY3
+except ImportError:
+    from collections import Iterable, Sequence, Mapping  # PY2
 
 __all__ = ['CompoundType', 'MultiType', 'ModelType', 'ListType', 'DictType',
     'PolyModelType']

--- a/schematics/types/union.py
+++ b/schematics/types/union.py
@@ -17,7 +17,11 @@ __all__ = ['UnionType']
 def _valid_init_args(type_):
     args = set()
     for cls in type_.__mro__:
-        args.update(inspect.getargspec(cls.__init__).args[1:])
+        try:
+            init_args = inspect.getfullargspec(cls.__init__).args[1:]  # PY3
+        except AttributeError:
+            init_args = inspect.getargspec(cls.__init__).args[1:]  # PY2
+        args.update(init_args)
         if cls is BaseType:
             break
     return args

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -2,10 +2,14 @@
 
 from __future__ import unicode_literals, absolute_import
 
-import collections
 import sys
 
 from .compat import *
+
+try:
+    from collections.abc import Sequence  # PY3
+except ImportError:
+    from collections import Sequence  # PY2
 
 if PY2:
     try:
@@ -59,7 +63,7 @@ def listify(value):
         return []
     elif isinstance(value, string_type):
         return [value]
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, Sequence):
         return list(value)
     else:
         return [value]

--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -120,7 +120,11 @@ def get_validation_context(**options):
 def prepare_validator(func, argcount):
     if isinstance(func, classmethod):
         func = func.__get__(object).__func__
-    if len(inspect.getargspec(func).args) < argcount:
+    try:
+        func_args = inspect.getfullargspec(func).args  # PY3
+    except AttributeError:
+        func_args = inspect.getargspec(func).args  # PY2
+    if len(func_args) < argcount:
         @functools.wraps(func)
         def newfunc(*args, **kwargs):
             if not kwargs or kwargs.pop('context', 0) is 0:

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     install_requires=[],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, pypy3
+envlist = py27, py33, py34, py35, py36, py37, pypy, pypy3
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
I made some modifications to get rid of the deprecation warnings related to Python 3. I also modified the configuration to run the tests on Python 3.7. 