### PR TITLE
fix export for UnionType that contains ModelType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/_build
 /.cache
 .coverage
 *.sqlite3
+.idea/

--- a/schematics/types/union.py
+++ b/schematics/types/union.py
@@ -84,6 +84,13 @@ class UnionType(BaseType):
         field, native_value = self._resolve(value, context)
         return native_value
 
+    def export(self, value, format, context=None):
+        for field in self._types.values():
+            if type(value) == field.native_type:
+                return field.export(value, format, context)
+
+        return self.export_mapping[format](value, context)
+
     def validate(self, value, context=None):
         field, _ = self._resolve(value, context)
         return field.validate(value, context)

--- a/tests/test_union_type.py
+++ b/tests/test_union_type.py
@@ -10,7 +10,6 @@ from schematics.exceptions import *
 from schematics.models import Model
 from schematics.types import *
 from schematics.types.compound import *
-from schematics.types.serializable import Serializable
 
 
 def test_id_or_uuid():
@@ -111,3 +110,12 @@ def test_invalid_args():
     with pytest.raises(TypeError):
         UnionType((IntType, dict))
 
+
+def test_model_type():
+    class Child(Model):
+        a = StringType()
+
+    class Parent(Model):
+        child = UnionType((ModelType(Child),))
+
+    assert Parent({'child': {'a': 4}}).to_primitive(), {'a': 4}


### PR DESCRIPTION
fixes https://github.com/schematics/schematics/issues/566

i'm not sure if this is the best place to do this. it seems like maybe `export_mapping` could contain this information, but i'm not sure.