### PR TITLE
Fixed Model.import_data for empty dict

### DIFF
--- a/schematics/models.py
+++ b/schematics/models.py
@@ -286,7 +286,7 @@ class Model(object):
         :param raw_data:
             New data to be imported and converted
         """
-        raw_data = _dict(raw_data) if raw_data else self._data.converted
+        raw_data = _dict(raw_data) if raw_data is not None else self._data.converted
         kwargs['trusted_data'] = kwargs.get('trusted_data') or {}
         kwargs['convert'] = getattr(context, 'convert', kwargs.get('convert', True))
         if self._data.unsafe:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -630,6 +630,30 @@ def test_nested_model_import_data_with_mappings():
     assert root.nxt_level.nested_attr == 'nested value'
 
 
+def test_import_data_for_empty_dict():
+    """Make sure that the whole object is not reimported in case an empty dict is given to ``import_data``"""
+
+    class EncodedStringType(StringType):
+        def to_native(self, value, context=None):
+            return value + ' (native)'
+
+        def to_primitive(self, value, context=None):
+            return value[:-9]
+
+    class Root(Model):
+        str_value = EncodedStringType()
+        other_value = IntType()
+
+    original_data = dict(str_value='Lorem ipsum', other_value=5)
+    root = Root(original_data)
+
+    root.import_data({})
+    # which really is a valid case when the dict is created dynamically somewhere else
+    # (and not by the user explicitly, e.g. a PUT request from the API)
+    # and we don't want the user to add additional emptiness checks (why should they?)
+    assert root.to_primitive() == original_data, 'Original data was not preserved'
+
+
 class SimpleModel(Model):
     field1 = StringType()
     field2 = StringType()


### PR DESCRIPTION
If you call `Model.import_dict()` with a dictionary that is created by some other part of your program, it might be empty, but the `import_dict` method should still work the same way as it would if the dictionary had any values in it, i.e. convert only the incoming data. Otherwise it leads to data being converted twice, which is unacceptable as it can cause corruption of the stored data.