### PR TITLE
Add test coverage for model validation inside Dict/List

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -165,11 +165,36 @@ def test_nested_model_validators():
 
     class MainModel(Model):
         modelfield = ModelType(SubModel)
+        named_modelfield = DictType(ModelType(SubModel))
+        listed_modelfield = ListType(ModelType(SubModel))
 
     with pytest.raises(DataError):
-        MainModel({'modelfield': {'should_raise': True}}).validate()
+        try:
+            MainModel({
+                'modelfield': {'should_raise': True},
+                'named_modelfield': {
+                    'one': {'should_raise': True}
+                },
+                'listed_modelfield': [
+                    {'should_raise': True},
+                ]
+            }).validate()
+        except DataError as exc:
+            assert len(exc.errors) == 3
+            assert exc.errors['listed_modelfield'][0]['should_raise'][0].summary == 'message'
+            assert exc.errors['named_modelfield']['one']['should_raise'][0].summary == 'message'
 
-    MainModel({'modelfield': {'should_raise': False}}).validate()
+            raise
+
+    MainModel({
+        'modelfield': {'should_raise': False},
+        'named_modelfield': {
+            'one': {'should_raise': False}
+        },
+        'listed_modelfield': [
+            {'should_raise': False},
+        ]
+    }).validate()
 
 
 def test_multi_key_validation():


### PR DESCRIPTION
This PR adds no functionality, it simply expands test coverage.

While troubleshooting something I had a moment of doubt about if schematics was properly doing ModelType validation on nested models inside of DictType orListType containers and since I couldn't find a test for it I decided to write one to cover it -- and everything works as I expected.