### PR TITLE
Removed usages of deprecated fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: help env test
+
+VENV=venv
+PIP=$(VENV)/bin/pip
+COVERAGE=$(VENV)/bin/coverage
+
+help:
+	@echo "======================================================="
+	@echo "=============== schematics dev commands ==============="
+	@echo "======================================================="
+	@echo "env \t\tsetup virtualenv"
+	@echo "tests \t\tsetup virtualenv and run tests in it"
+
+env:
+	test -d $(VENV) || virtualenv $(VENV) || @echo "please install virtualenv"
+	$(PIP) install -r test-requirements.txt
+	$(PIP) install -e .
+
+test: env
+	$(COVERAGE) run --source schematics -m py.test
+	$(COVERAGE) report

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Schematics
    :alt: Build Status
 
 .. image:: https://coveralls.io/repos/github/schematics/schematics/badge.svg?branch=master
-   :target: https://coveralls.io/github/schematics/schematics?branch=master 
+   :target: https://coveralls.io/github/schematics/schematics?branch=master
    :alt: Coverage
 
 
@@ -42,7 +42,7 @@ Some common use cases:
 Example
 =======
 
-This is a simple Model. 
+This is a simple Model.
 
 .. code:: python
 
@@ -96,5 +96,5 @@ Testing & Coverage support
 
 Run coverage and check the missing statements. ::
 
-  $ coverage run --source schematics -m py.test && coverage report
+  $ make test # sets up virtualenv and runs tests + coverage
 

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Let's try validating without a name value, since it's required.
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "schematics/models.py", line 231, in validate
-      raise DataError(e.messages)
+      raise DataError(e.errors)
   schematics.exceptions.DataError: {'name': ['This field is required.']}
 
 Add the field and validation passes.

--- a/docs/basics/quickstart.rst
+++ b/docs/basics/quickstart.rst
@@ -70,7 +70,7 @@ And this is what it looks like when validation fails.
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "schematics/models.py", line 229, in validate
-      raise ModelValidationError(e.messages)
+      raise ModelValidationError(e.errors)
   schematics.exceptions.ModelValidationError: {'taken_at': [u'Could not parse whatever. Should be ISO8601.']}
 
 
@@ -81,7 +81,7 @@ Serialization comes in two primary forms.  In both cases the data is produced
 as a dictionary.
 
 The ``to_primitive()`` function will reduce the native Python types into string
-safe formats.  For example, the ``DateTimeType`` from above is stored as a 
+safe formats.  For example, the ``DateTimeType`` from above is stored as a
 Python ``datetime``, but it will serialize to an ISO8601 format string.
 
 ::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Schematics
    :alt: Build Status
 
 .. image:: https://coveralls.io/repos/github/schematics/schematics/badge.svg?branch=development
-   :target: https://coveralls.io/github/schematics/schematics?branch=development 
+   :target: https://coveralls.io/github/schematics/schematics?branch=development
    :alt: Coverage
 
 .. toctree::
@@ -83,7 +83,7 @@ Let's try validating without a name value, since it's required. ::
   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
     File "schematics/models.py", line 231, in validate
-      raise DataError(e.messages)
+      raise DataError(e.errors)
   schematics.exceptions.DataError: {'name': ['This field is required.']}
 
 Add the field and validation passes::

--- a/docs/usage/validation.rst
+++ b/docs/usage/validation.rst
@@ -29,7 +29,7 @@ Validation Errors
 =================
 
 Validation failures throw an exception called ``ValidationError``.  A
-description of what failed is stored in ``messages``, which is a dictionary
+description of what failed is stored in ``errors``, which is a dictionary
 keyed by the field name with a list of reasons the field failed.
 
 ::
@@ -38,7 +38,7 @@ keyed by the field name with a list of reasons the field failed.
   >>> try:
   ...     p.validate()
   ... except ValidationError, e:
-  ...    print e.messages
+  ...    print e.errors
   {'bio': [u'This field is required.']}
 
 

--- a/schematics/iteration.py
+++ b/schematics/iteration.py
@@ -56,7 +56,8 @@ def atoms(schema, mapping, keys=tuple(Atom._fields), filter=None):
     has_field = 'field' in keys
     has_value = (mapping is not None) and ('value' in keys)
 
-    for field_name, field in iteritems(schema.fields):
+    schema_fields = getattr(schema, '_schema', schema).fields
+    for field_name, field in iteritems(schema_fields):
         value = Undefined
 
         if has_value:

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -44,7 +44,7 @@ class FieldDescriptor(object):
         For a model class, returns the field's type object.
         """
         if instance is None:
-            return cls._fields[self.name]
+            return cls._schema.fields[self.name]
         else:
             value = instance._data.get(self.name, Undefined)
             if value is Undefined:
@@ -56,7 +56,7 @@ class FieldDescriptor(object):
         """
         Sets the field's value.
         """
-        field = instance._fields[self.name]
+        field = instance._schema.fields[self.name]
         value = field.pre_setattr(value)
         instance._data.converted[self.name] = value
 
@@ -368,7 +368,7 @@ class Model(object):
         context._setdefault('memo', set())
         context.memo.add(cls)
         values = {}
-        for name, field in cls.fields.items():
+        for name, field in cls._schema.fields.items():
             if name in overrides:
                 continue
             if getattr(field, 'model_class', None) in context.memo:

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -399,8 +399,9 @@ class Model(object):
             raise UnknownFieldError(self, name)
 
     def __contains__(self, name):
-        return (name in self._data and getattr(self, name, Undefined) is not Undefined) \
-            or name in self._serializables
+        return (
+            name in self._data and getattr(self, name, Undefined) is not Undefined
+        ) or isinstance(self._schema.fields.get(name), Serializable)
 
     def __len__(self):
         return len(self._data)

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -100,7 +100,7 @@ def import_loop(schema, mutable, raw_data=None, field_converter=None, trusted_da
 
     if got_data:
         # Determine all acceptable field input names
-        all_fields = schema._valid_input_keys
+        all_fields = getattr(schema, '_schema', schema).valid_input_keys
         if context.mapping:
             mapped_keys = (set(itertools.chain(*(
                           listify(input_keys) for target_key, input_keys in context.mapping.items()
@@ -246,19 +246,21 @@ def export_loop(schema, instance_or_dict, field_converter=None, role=None, raise
 
     instance_or_dict = context.field_converter.pre(schema, instance_or_dict, context)
 
-    if schema._options.export_order:
+    schema_options = getattr(schema, '_schema', schema).options
+
+    if schema_options.export_order:
         data = OrderedDict()
     else:
         data = {}
 
     filter_func = (context.role if callable(context.role) else
-        schema._options.roles.get(context.role))
+        schema_options.roles.get(context.role))
     if filter_func is None:
         if context.role and context.raise_error_on_role:
             error_msg = '%s Model has no role "%s"'
             raise ValueError(error_msg % (schema.__name__, context.role))
         else:
-            filter_func = schema._options.roles.get("default")
+            filter_func = schema_options.roles.get("default")
 
     _field_converter = context.field_converter
 

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -258,7 +258,7 @@ def export_loop(schema, instance_or_dict, field_converter=None, role=None, raise
     if filter_func is None:
         if context.role and context.raise_error_on_role:
             error_msg = '%s Model has no role "%s"'
-            raise ValueError(error_msg % (schema.__name__, context.role))
+            raise ValueError(error_msg % (schema.name, context.role))
         else:
             filter_func = schema_options.roles.get("default")
 

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -251,7 +251,7 @@ class BaseType(object):
 
     def get_export_level(self, context):
         if self.owner_model:
-            level = self.owner_model._options.export_level
+            level = getattr(self.owner_model, '_schema', self.owner_model).options.export_level
         else:
             level = DEFAULT
         if self.export_level is not None:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -7,6 +7,7 @@ import itertools
 from ..common import *
 from ..exceptions import *
 from ..transforms import (
+    convert,
     export_loop,
     get_import_context, get_export_context,
     to_native_converter, to_primitive_converter)
@@ -159,7 +160,8 @@ class ModelType(CompoundType):
         if context.convert and context.oo:
             return model_class(value, context=context)
         else:
-            return model_class.convert(value, context=context)
+            return convert(
+                model_class._schema, value, oo=True, context=context)
 
     def _export(self, value, format, context):
         if isinstance(value, Model):

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -30,7 +30,7 @@ def test_reason_why_we_must_bind_fields():
     assert p1.name != p2.name
     assert id(p1.name) != id(p2.name)
 
-    assert id(p1._fields["name"]) == id(p2._fields["name"])
+    assert id(p1._schema.fields["name"]) == id(p2._schema.fields["name"])
 
 
 def test_reason_why_we_must_bind_fields_model_field():
@@ -62,7 +62,7 @@ def test_reason_why_we_must_bind_fields_model_field():
     assert p1.location != p2.location
     assert id(p1.location) != id(p2.location)
 
-    assert id(p1._fields["location"]) == id(p2._fields["location"])
+    assert id(p1._schema.fields["location"]) == id(p2._schema.fields["location"])
 
 
 def test_field_binding():
@@ -124,13 +124,13 @@ def test_field_inheritance():
         field2 = StringType(required=True)
         field3 = StringType()
 
-    assert A.field1 is A._fields['field1'] is not B._fields['field1']
-    assert A.field2 is A._fields['field2'] is not B._fields['field2']
-    assert 'field3' not in A._fields
+    assert A.field1 is A._schema.fields['field1'] is not B._schema.fields['field1']
+    assert A.field2 is A._schema.fields['field2'] is not B._schema.fields['field2']
+    assert 'field3' not in A._schema.fields
 
-    assert B.field1 is B._fields['field1']
-    assert B.field2 is B._fields['field2']
-    assert B.field3 is B._fields['field3']
+    assert B.field1 is B._schema.fields['field1']
+    assert B.field2 is B._schema.fields['field2']
+    assert B.field3 is B._schema.fields['field3']
 
     assert A.field2.required is False and B.field2.required is True
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -110,8 +110,8 @@ def test_serializable_doesnt_keep_global_state():
     location_US = Location({"country_code": "US"})
     location_IS = Location({"country_code": "IS"})
 
-    assert id(location_US._serializables["country_name"]) == id(
-        location_IS._serializables["country_name"])
+    assert id(location_US._schema.fields["country_name"]) == id(
+        location_IS._schema.fields["country_name"])
 
 
 def test_field_inheritance():
@@ -145,8 +145,8 @@ def test_serializable_inheritance():
     class B(A):
         pass
 
-    assert A.s is A._serializables['s'] is not B._serializables['s']
-    assert B.s is B._serializables['s']
+    assert A.s is A._schema.fields['s'] is not B._schema.fields['s']
+    assert B.s is B._schema.fields['s']
     assert A.s.type is not B.s.type
     assert A.s.fget is B.s.fget
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,15 +9,15 @@ from schematics.exceptions import *
 def test_error_from_string():
 
     e = ConversionError('hello')
-    assert e.messages == ['hello']
+    assert e.errors == ['hello']
 
     e = ValidationError('hello', 'world', '!')
-    assert e.messages == ['hello', 'world', '!']
+    assert e.errors == ['hello', 'world', '!']
     assert len(e) == 3
 
 
 def _assert(e):
-    assert e.messages == ['hello'] and e.messages[0].info == 99
+    assert e.errors == ['hello'] and e.errors[0].info == 99
 
 
 def test_error_from_args():
@@ -44,7 +44,7 @@ def test_error_from_mixed_args():
             ErrorMessage('from_msg', info=0),
             ValidationError('from_err', info=1))
 
-    assert e == e.messages == ['hello', 'world', 'from_msg', 'from_err']
+    assert e == e.errors == ['hello', 'world', 'from_msg', 'from_err']
     assert [msg.info for msg in e] == [99, None, 0, 1]
 
 
@@ -56,8 +56,8 @@ def test_error_from_mixed_list():
             ErrorMessage('from_msg', info=0),
             ConversionError('from_err', info=1)])
 
-    assert e.messages == ['hello', 'world', 'from_msg', 'from_err']
-    assert [msg.info for msg in e.messages] == [99, None, 0, 1]
+    assert e.errors == ['hello', 'world', 'from_msg', 'from_err']
+    assert [msg.info for msg in e.errors] == [99, None, 0, 1]
 
 
 def test_error_str():
@@ -74,7 +74,7 @@ def test_error_str():
 
 def test_error_list_conversion():
     err = ValidationError("A", "B", "C")
-    assert list(err) == err.messages
+    assert list(err) == err.errors
 
 
 def test_error_eq():

--- a/tests/test_export_level.py
+++ b/tests/test_export_level.py
@@ -36,10 +36,10 @@ def models(request):
         modelfield2 = ModelType(N)
 
     if m_level:
-        M._options.export_level = m_level
+        M._schema.options.export_level = m_level
 
     if n_level:
-        N._options.export_level = n_level
+        N._schema.options.export_level = n_level
 
     return M, N
 
@@ -63,8 +63,8 @@ input = {
 def test_export_level(models):
 
     M, N = models
-    m_level = M._options.export_level
-    n_level = N._options.export_level
+    m_level = M._schema.options.export_level
+    n_level = N._schema.options.export_level
 
     output = M(input, init=False).to_primitive()
 
@@ -152,8 +152,8 @@ def test_export_level(models):
 def test_export_level_override(models):
 
     M, N = models
-    m_level = M._options.export_level
-    n_level = N._options.export_level
+    m_level = M._schema.options.export_level
+    n_level = N._schema.options.export_level
 
     m = M(input, init=False)
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -49,7 +49,7 @@ def test_validate_strict_with_trusted_data():
     try:
         validate(Player, {'id': 4}, strict=True, trusted_data={'name': 'Arthur'})
     except ValidationError as e:
-        assert 'name' in e.messages
+        assert 'name' in e.errors
 
 
 def test_validate_partial_with_trusted_data():
@@ -75,6 +75,6 @@ def test_validate_with_instance_level_validators():
     try:
         validate(Player, p1, {'id': 3})
     except DataError as e:
-        assert 'id' in e.messages
-        assert 'Cannot change id' in e.messages['id']
+        assert 'id' in e.errors
+        assert 'Cannot change id' in e.errors['id']
         assert p1.id == 4

--- a/tests/test_list_type.py
+++ b/tests/test_list_type.py
@@ -131,19 +131,19 @@ def test_validation_with_size_limits():
         c = Card({"users": None})
         c.validate()
 
-    assert exception.value.messages['users'] == [u'This field is required.']
+    assert exception.value.errors['users'] == [u'This field is required.']
 
     with pytest.raises(DataError) as exception:
         c = Card({"users": []})
         c.validate()
 
-    assert exception.value.messages['users'] == [u'Please provide at least 1 item.']
+    assert exception.value.errors['users'] == [u'Please provide at least 1 item.']
 
     with pytest.raises(DataError) as exception:
         c = Card({"users": [User(), User(), User()]})
         c.validate()
 
-    assert exception.value.messages['users'] == [u'Please provide no more than 2 items.']
+    assert exception.value.errors['users'] == [u'Please provide no more than 2 items.']
 
 
 def test_list_field_required():
@@ -200,7 +200,7 @@ def test_list_model_field():
     with pytest.raises(DataError) as exception:
         c.validate()
 
-    errors = exception.value.messages
+    errors = exception.value.errors
     assert errors['users'] == [u'This field is required.']
 
 
@@ -215,7 +215,7 @@ def test_list_model_field_exception_with_full_message():
 
     with pytest.raises(DataError) as exception:
         g.validate()
-    assert exception.value.messages == {'users': {0: {'name': ['String value is too long.']}}}
+    assert exception.value.errors == {'users': {0: {'name': ['String value is too long.']}}}
 
 
 def test_compound_fields():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -348,7 +348,7 @@ def test_options_custom_args():
             _foo = 'bar'
 
     f = Foo()
-    assert f._options._foo == 'bar'
+    assert f._schema.options._foo == 'bar'
 
 
 def test_options_custom_args_inheritance():
@@ -361,8 +361,8 @@ def test_options_custom_args_inheritance():
             _bar = 'baz'
 
     m = Moo()
-    assert m._options._foo == 'bar'
-    assert m._options._bar == 'baz'
+    assert m._schema.options._foo == 'bar'
+    assert m._schema.options._bar == 'baz'
 
 
 def test_no_options_args():
@@ -379,7 +379,7 @@ def test_options_parsing_from_model():
             roles = {}
 
     f = Foo()
-    fo = f._options
+    fo = f._schema.options
 
     assert fo.__class__ == ModelOptions
     assert fo.namespace == 'foo'
@@ -398,7 +398,7 @@ def test_options_parsing_from_optionsclass():
         __optionsclass__ = FooOptions
 
     f = Foo()
-    fo = f._options
+    fo = f._schema.options
 
     assert fo.__class__ == FooOptions
     assert fo.namespace == 'foo'
@@ -422,7 +422,7 @@ def test_subclassing_preservers_roles():
         "age": 87
     })
 
-    options = gramps._options
+    options = gramps._schema.options
 
     assert options.roles == {
         "public": blacklist("id"),
@@ -459,7 +459,7 @@ def test_subclassing_overides_roles():
         "family_secret": "Secretly Canadian"
     })
 
-    options = gramps._options
+    options = gramps._schema.options
 
     assert options.roles == {
         "grandchildren": whitelist("age"),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -190,7 +190,7 @@ def test_raises_validation_error_on_non_partial_validate():
 
     with pytest.raises(DataError) as exception:
         u.validate()
-    assert exception.value.messages, {"bio": [u"This field is required."]}
+    assert exception.value.errors, {"bio": [u"This field is required."]}
 
 
 def test_model_inheritance():
@@ -235,7 +235,7 @@ def test_validation_fails_if_internal_state_is_invalid():
     with pytest.raises(DataError) as exception:
         u.validate()
 
-    assert exception.value.messages, {
+    assert exception.value.errors, {
         "name": ["This field is required."],
         "age": ["This field is required."],
     }
@@ -253,7 +253,7 @@ def test_returns_nice_conversion_errors():
     with pytest.raises(DataError) as exception:
         User({"name": "Jóhann", "age": "100 years"})
 
-    errors = exception.value.messages
+    errors = exception.value.errors
 
     assert errors == {
         "age": [u'Value \'100 years\' is not int.'],

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -892,7 +892,7 @@ def test_role_set_operations():
     user = User(
         dict(
             (k, v) for k, v in data.items()
-            if k in User._options.roles['create']  # filter by 'create' role
+            if k in User._schema.options.roles['create']  # filter by 'create' role
         )
     )
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -66,7 +66,7 @@ def test_validation_none_fails():
     with pytest.raises(DataError) as exception:
         Player({"first_name": None}).validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
     assert len(messages) == 1  # Only one failure
     assert messages["first_name"][0] == 'This field is required.'
 
@@ -93,7 +93,7 @@ def test_custom_validators():
             "title": "Old Man"
         }).validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
     assert future_error_msg in messages['publish']
 
 
@@ -107,7 +107,7 @@ def test_messages_subclassing():
     with pytest.raises(DataError) as exception:
         TestDoc({'title': None}).validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
     assert u'Never forget' in messages['title']
 
 
@@ -118,7 +118,7 @@ def test_messages_instance_level():
     with pytest.raises(DataError) as exception:
         TestDoc({'title': None}).validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
     assert u'Never forget' in messages['title']
 
 
@@ -257,7 +257,7 @@ def test_basic_error():
     with pytest.raises(DataError) as exception:
         school.validate()
 
-    errors = exception.value.messages
+    errors = exception.value.errors
 
     assert "name" in errors
     assert errors["name"] == ["This field is required."]
@@ -278,7 +278,7 @@ def test_deep_errors():
     with pytest.raises(DataError) as exception:
         school.validate()
 
-    errors = exception.value.messages
+    errors = exception.value.errors
 
     assert "headmaster" in errors
     assert "name" in errors["headmaster"]
@@ -320,7 +320,7 @@ def test_deep_errors_with_lists(idx1, idx2):
     with pytest.raises(DataError) as exception:
         school.validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
 
     assert messages == {
         'courses': {
@@ -355,7 +355,7 @@ def test_merge_serializable_errors():
     with pytest.raises(DataError) as exception:
         person.validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
 
     assert "age" in messages
     assert "name" in messages
@@ -399,7 +399,7 @@ def test_deep_errors_with_dicts():
     with pytest.raises(DataError) as exception:
         school.validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
 
     assert messages == {
         'courses': {
@@ -449,7 +449,7 @@ def test_custom_validator_raising_dicterror():
     with pytest.raises(DataError) as exception:
         foo.validate()
 
-    messages = exception.value.messages
+    messages = exception.value.errors
 
     assert messages == {
         'bar': {
@@ -537,12 +537,12 @@ def test_validate_apply_defaults():
 
 def test_clean_validation_messages():
     error = ValidationError("A")
-    assert error.messages == ["A"]
+    assert error.errors == ["A"]
 
 
 def test_clean_validation_messages_list():
     error = ValidationError(["A", "B", "C"])
-    assert error.messages, ["A", "B", "C"]
+    assert error.errors, ["A", "B", "C"]
 
 
 def test_builtin_conversion_exception():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -500,8 +500,8 @@ def test_model_validator_override():
         def validate_bar(self, data, value, context=None):
             pass
 
-    assert Child._validator_functions['foo'] is Base._validator_functions['foo']
-    assert Child._validator_functions['bar'] is not Base._validator_functions['bar']
+    assert Child._schema.validators['foo'] is Base._schema.validators['foo']
+    assert Child._schema.validators['bar'] is not Base._schema.validators['bar']
 
 
 def test_validate_convert():


### PR DESCRIPTION
(preface) Hi o/ not sure if you're looking for PRs in this category of work but I saw https://github.com/schematics/schematics/issues/571 and it was annoying me in my builds, so I thought I would try to solve it instead of piling on. That being said, I did a very naive refactor based on what I understood. Ya'll might have had more comprehensive plans about how you wanted to arrange things. But hopefully this is roughly in the ballpark. (/preface)

There were a number of deprecation errors being emitted from the package, so I have attempted to update all those references by essentially taking the wrapping code and moving it closer to the calling site. I did my best with the understanding of the interactions.

I have also added a `Makefile` that makes is easier to set up a dev environment and get tests running. I realize I am imposing this, so let me know if you would rather not have this.

#### Makefile output:
```bash
$ make
=======================================================
=============== schematics dev commands ===============
=======================================================
env 		setup virtualenv
tests 		setup virtualenv and run tests in it

$ make env
test -d venv || virtualenv venv || @echo "please install virtualenv"
venv/bin/pip install -r test-requirements.txt
... pip do the installs ...
Successfully installed schematics

$ make test
... does `make env`
coverage pytest ... # the command from the README
```