### PR TITLE
Fixed typo

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,7 +12,7 @@ from schematics.exceptions import *
 def test_dict_methods_in_model():
     """
     a regression test to ensure that an issue where attributes on
-    dictionaries are not being misintrepreted as actual schematics
+    dictionaries are not being misinterpreted as actual schematics
     fields.
     """
 
@@ -25,7 +25,7 @@ def test_dict_methods_in_model():
 
 def test_dict_methods_in_model_atoms():
     """
-    atoms should return the raw values, and not call any overriden methods.
+    atoms should return the raw values, and not call any overridden methods.
     """
     class M(Model):
         get = IntType()


### PR DESCRIPTION
test_models.py had a typo in the documentation