### PR TITLE
Support enum._missing_ classmethod override (>= python3.6)

### DIFF
--- a/schematics/contrib/enum_type.py
+++ b/schematics/contrib/enum_type.py
@@ -65,9 +65,10 @@ class EnumType(BaseType):
     def _find_by_value(self, value):
         if not self._use_values:
             return
-        for member in self._enum_class:
-            if member.value == value:
-                return member
+        try:
+            return self._enum_class(value)
+        except ValueError:
+            pass
 
     def to_primitive(self, value, context=None):
         if isinstance(value, Enum):


### PR DESCRIPTION
Enable to use `Enum._missing_` classmethod overriding. 

This method is available after Python3.6.
https://docs.python.org/3.6/library/enum.html#supported-sunder-names

To enable `_missing_` override, use `Enum(value)` instead of checking each value by for-loop.