### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/schematics/validate.py
+++ b/schematics/validate.py
@@ -127,7 +127,7 @@ def prepare_validator(func, argcount):
     if len(func_args) < argcount:
         @functools.wraps(func)
         def newfunc(*args, **kwargs):
-            if not kwargs or kwargs.pop('context', 0) is 0:
+            if not kwargs or kwargs.pop('context', 0) == 0:
                 args = args[:-1]
             return func(*args, **kwargs)
         return newfunc

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 
 with open(os.path.join(os.path.dirname(__file__), 'schematics/__init__.py')) as f:
-    version = re.search("^__version__ = '(\d\.\d+\.\d+(\.?(dev|a|b|rc)\d?)?)'$",
+    version = re.search(r"^__version__ = '(\d\.\d+\.\d+(\.?(dev|a|b|rc)\d?)?)'$",
                   f.read(), re.M).group(1)
 
 setup(


### PR DESCRIPTION
Fixes #602 . Also fixes deprecation warning due to invalid escape sequences in setup.py.