### PR TITLE
rework email validation regex

### DIFF
--- a/schematics/types/net.py
+++ b/schematics/types/net.py
@@ -265,15 +265,7 @@ class EmailType(StringType):
         'email': _("Not a well-formed email address.")
     }
 
-    EMAIL_REGEX = re.compile(r"""^(
-        ( ( [%(atext)s]+ (\.[%(atext)s]+)* ) | ("( [%(qtext)s\s] | \\[%(vchar)s\s] )*") )
-        @((?!-)[A-Z0-9-]{1,63}(?<!-)\.)+[A-Z]{2,63})$"""
-        % {
-            'atext': '-A-Z0-9!#$%&\'*+/=?^_`{|}~',
-            'qtext': '\x21\x23-\x5B\\\x5D-\x7E',
-            'vchar': '\x21-\x7E'
-        },
-        re.I + re.X)
+    EMAIL_REGEX = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
 
     def _mock(self, context=None):
         return fill_template('%s@example.com', self.min_length,

--- a/tests/test_types_net.py
+++ b/tests/test_types_net.py
@@ -164,10 +164,11 @@ def test_url_type_with_unreachable_url():
 def test_email_type_with_valid_addresses():
     field = EmailType()
     addrs = [
-        r'"()\\\<>[]:,;@!\"#$%&*+-/=?^_`{}|~.a"@example.org',
-        u'"foo bar baz"@example.org',
+        u'foo_bar_baz@example.org',
         u'Z@foo.zz',
-        u'123.qwe.asd@foo.bar.baz'
+        u'123.qwe.asd@foo.bar.baz',
+        u'mky@xamp-le.com',
+        u'TEST@TEST.TEST',
     ]
     for addr in addrs:
         field.validate(addr)
@@ -176,12 +177,21 @@ def test_email_type_with_valid_addresses():
 def test_email_type_with_invalid_addresses():
     field = EmailType()
     addrs = [
+        r'"()\\\<>[]:,;@!\"#$%&*+-/=?^_`{}|~.a"@example.org',
         r'"qweasd\"@example.org',
         u'"qwe"asd"@example.org',
         u'curaçao@example.org',
         u'foo@local',
+        u't_e_s_t@test.t_e_s_t',
+        u'testing@gmai',
+        u't_e_s_t@t_e_s_t.t_e_s_t',
+        u'hello@',
+        u'totaly()@not.email',
+        u'd|vor@mail.ru',
+        u'with/slash@gmail.com',
+        u'ivan.***@mail.ru',
+        u'"foo bar baz"@example.org',
     ]
     for addr in addrs:
         with pytest.raises(ValidationError):
             field.validate(addr)
-


### PR DESCRIPTION
There is a couple of emails that I found invalid but Schematics validator passed them as OK.
Examples are: with/slash@gmail.com, ivan.***@mail.ru, d|vor@mail.ru

Changed: email validation regex
Add: unittests