### PR TITLE
Add metadata to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url='https://github.com/schematics/schematics',
     download_url='https://github.com/schematics/schematics/archive/v%s.tar.gz' % version,
     packages=['schematics', 'schematics.types', 'schematics.contrib', 'schematics.extensions'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*',
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,17 @@ with open(os.path.join(os.path.dirname(__file__), 'schematics/__init__.py')) as 
     version = re.search(r"^__version__ = '(\d\.\d+\.\d+(\.?(dev|a|b|rc)\d?)?)'$",
                   f.read(), re.M).group(1)
 
+
+with open('README.rst') as f:
+    long_description = f.read()
+
+
 setup(
     name='schematics',
     license='BSD',
     version=version,
     description='Python Data Structures for Humans',
+    long_description=long_description,
     author=u'James Dennis, Jökull Sólberg, Jóhann Þorvaldur Bergþórsson, Kalle Tuure, Paul Eipper',
     author_email='jdennis@gmail.com, jokull@plainvanillagames.com, johann@plainvanillagames.com, kalle@goodtimes.fi, paul@nkey.com.br',
     url='https://github.com/schematics/schematics',


### PR DESCRIPTION
Two things:

* Add `long_description`:
  https://pypi.org/project/schematics/ says only "The author of this package has not provided a project description". Instead, it's common to put the README contents in the `long_description` so it shows up on PyPI. Modern versions of setuptools, wheel and twine are needed, more info: https://packaging.python.org/guides/making-a-pypi-friendly-readme/

* Add `python_requires`:
  This helps pip choose the relevant version of this library for the user's running Python version. When EOL Python versions are dropped, set this to `python_requires='>=3.6`.
