### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/usage/extending.rst
+++ b/docs/usage/extending.rst
@@ -6,14 +6,14 @@
 Extending
 =======
 
-For most non trivial cases, the base types may not be enough. Schematics is designed to be flexible to allow for extending data types in order to accomodate custom logic.
+For most non trivial cases, the base types may not be enough. Schematics is designed to be flexible to allow for extending data types in order to accommodate custom logic.
 
 Simple Example
 =============
 
 A simple example is allowing for value transformations. 
 
-Say that there is a model that requires email validation. Since emails are case insenstive, it might be helpful to convert the input email to lower case before continuing to validate. 
+Say that there is a model that requires email validation. Since emails are case insensitive, it might be helpful to convert the input email to lower case before continuing to validate. 
 
 This can be achieved by Extending the Email class 
 

--- a/schematics/compat.py
+++ b/schematics/compat.py
@@ -25,14 +25,14 @@ if PY2:
     iteritems = operator.methodcaller('iteritems')
     itervalues = operator.methodcaller('itervalues')
 
-    # reraise code taken from werzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
+    # reraise code taken from werkzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
 else:
     string_type = str
     iteritems = operator.methodcaller('items')
     itervalues = operator.methodcaller('values')
 
-    # reraise code taken from werzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
+    # reraise code taken from werkzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
     def reraise(tp, value, tb=None):
         if value.__traceback__ is not tb:
             raise value.with_traceback(tb)

--- a/schematics/util.py
+++ b/schematics/util.py
@@ -83,7 +83,7 @@ class ImportStringError(ImportError):
 
     """Provides information about a failed :func:`import_string` attempt.
 
-    Code taken from werzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
+    Code taken from werkzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
     """
 
     #: String in dotted notation that failed to be imported.
@@ -134,7 +134,7 @@ def import_string(import_name, silent=False):
 
     If `silent` is True the return value will be `None` if the import fails.
 
-    Code taken from werzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
+    Code taken from werkzeug BSD license at https://github.com/pallets/werkzeug/blob/master/LICENSE
 
     :param import_name: the dotted name for the object to import.
     :param silent: if set to `True` import errors are ignored and


### PR DESCRIPTION
There are small typos in:
- docs/usage/extending.rst
- schematics/compat.py
- schematics/util.py

Fixes:
- Should read `werkzeug` rather than `werzeug`.
- Should read `insensitive` rather than `insenstive`.
- Should read `accommodate` rather than `accomodate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md