### PR TITLE
Update extending base type example in `extending.rst` .

### DIFF
--- a/docs/usage/extending.rst
+++ b/docs/usage/extending.rst
@@ -74,7 +74,7 @@ functions.
         ...         """
         ...         if 'converters' in kwargs:
         ...             self.converters = kwargs['converters']
-        ...         del kwargs['converters']
+        ...             del kwargs['converters']
         ...         super().__init__(**kwargs)
         ... 
         ...     def convert(self, value, context=None):


### PR DESCRIPTION
Ensure the example to extend base type class can handle cases where no converters are provided by the user. This modification allows the code to work correctly even if converters are not explicitly provided by the user.